### PR TITLE
Complete API/RPC functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,167 @@
+# Originally from https://github.com/github/gitignore/blob/95c8bf079cf5600d967696c7f253e352ae77d83d/Python.gitignore (CC0 License)
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -15,22 +15,24 @@ git clone https://github.com/CoulterStutz/python-xmrig.git && cd python-xmrig
 poetry install # or use `pip install .`, dont forget the period to set the source location to the current directory.
 ```
 
-After that the package will be available to use!
-
 ### Using PyPi
 
 ```shell
 poetry install xmrig # or use `pip install xmrig`.
 ```
 
+After that the package will be available to use!
+
 ## Example Usage
 
 Here is a basic implementation of the API Wrapper now dubbed XMRigAPI.
 
 ```python
-# Import the module and initialize the API wrapper.
-import xmrig
-x = xmrig.XMRigAPI(ip="127.0.0.1", port="5545", access_token="example")
+import xmrig, logging
+x = xmrig.XMRigAPI(ip="127.0.0.1", port="5555", access_token="example")
+logging.basicConfig()
+logging.getLogger("XMRigAPI").setLevel(logging.INFO)            # Change to DEBUG to print out all responses when their methods are called
+log = logging.getLogger("MyLOG")
 
 # Control the miner using JSON RPC.
 x.pause_miner()
@@ -38,15 +40,20 @@ x.resume_miner()
 x.stop_miner()
 x.start_miner()
 
+# Update cached data from endpoints individually or all at once
+x.update_summary()
+x.update_all_responses()
+
 # Edit and update the miners `config.json` via the HTTP API.
-config = x.get_config()
+x.update_config()                                               # This updates the cached data
+config = x.config()                                             # Use the `config` property to access the data
 config["pools"]["USER"] = "NEW_WALLET_ADDRESS"
 x.post_config(config)
 
 # Summary and Backends API data is available as properties in either full or individual format.
-print(x.summary)
-print(x.hashrates)  # Prints out the current hashrates
-print(x.accepted_jobs)  # Prints out the accepted_jobs counter
-print(x.rejected_jobs)  # Prints out the rejected_jobs counter
-print(x.current_difficulty)  # Prints out the current difficulty
+log.info(x.summary)                                             # Prints the entire `summary` endpoint response
+log.info(x.sum_hashrates)                                       # Prints out the current hashrates
+log.info(x.sum_pool_accepted_jobs)                              # Prints out the accepted_jobs counter
+log.info(x.sum_pool_rejected_jobs)                              # Prints out the rejected_jobs counter
+log.info(x.sum_current_difficulty)                              # Prints out the current difficulty
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # xmrig-python
-[![PyPi](https://img.shields.io/badge/PyPi-1.1-green?labelColor=026ab5&style=flat-square&logo=pypi&logoColor=ffffff&link=https://pypi.org/project/xmrig/)](https://pypi.org/project/xmrig/)
+[![PyPi](https://img.shields.io/badge/PyPi-1.1.1-green?labelColor=026ab5&style=flat-square&logo=pypi&logoColor=ffffff&link=https://pypi.org/project/xmrig/)](https://pypi.org/project/xmrig/)
 [![Python](https://img.shields.io/badge/Python-%203.9,%203.10,%203.11,%203.12-green?labelColor=026ab5&style=flat-square&logo=pypi&logoColor=ffffff&link=https://pypi.org/project/xmrig/)](https://pypi.org/project/xmrig/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/xmrig?label=PyPI%20Downloads)
 ![License](https://img.shields.io/github/license/CoulterStutz/python-xmrig?label=License&color=brightgreen)

--- a/README.md
+++ b/README.md
@@ -7,32 +7,45 @@
 A wrapper for the XMRig HTTP API and client manager
 
 ## Installing xmrig-python
-### Building From Source
+
+### From Source
+
 ```shell
 git clone https://github.com/CoulterStutz/python-xmrig.git && cd python-xmrig
+poetry install # or use `pip install .`, dont forget the period to set the source location to the current directory
 ```
-After installing from source, use poetry to install the package
-```shell
-poetry install
-```
-After that the package will be avalible to use!
 
-### Using Pip or Poetry
-#### Using Pip
+After that the package will be available to use!
+
+### Using PyPi
+
 ```shell
-pip install xmrig
-```
-#### Poetry
-```shell
-poetry install xmrig
+poetry install xmrig # or use `pip install xmrig`.
 ```
 
 ## Example Usage
-Here is a basic implementation of the API Wrapper now dubbed XMRigAPI in 1.1
+
+Here is a basic implementation of the API Wrapper now dubbed XMRigAPI.
+
 ```python
+# Import the module and initialize the API wrapper.
 import xmrig
 x = xmrig.XMRigAPI(ip="127.0.0.1", port="5545", access_token="example")
-print(x.hashrate)  # Prints out the current hashrate
+
+# Control the miner using JSON RPC
+x.pause_miner()
+x.resume_miner()
+x.stop_miner()
+x.start_miner()
+
+# Edit and update the miners `config.json` via the HTTP API
+config = x.get_config()
+config["pools"]["USER"] = "NEW_WALLET_ADDRESS"
+x.post_config(config)
+
+# Summary and Backends API data is available as properties in either full or individual format.
+print(x.summary)
+print(x.hashrates)  # Prints out the current hashrates
 print(x.accepted_jobs)  # Prints out the accepted_jobs counter
 print(x.rejected_jobs)  # Prints out the rejected_jobs counter
 print(x.current_difficulty)  # Prints out the current difficulty

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A wrapper for the XMRig HTTP API and client manager
 
 ```shell
 git clone https://github.com/CoulterStutz/python-xmrig.git && cd python-xmrig
-poetry install # or use `pip install .`, dont forget the period to set the source location to the current directory
+poetry install # or use `pip install .`, dont forget the period to set the source location to the current directory.
 ```
 
 After that the package will be available to use!
@@ -32,13 +32,13 @@ Here is a basic implementation of the API Wrapper now dubbed XMRigAPI.
 import xmrig
 x = xmrig.XMRigAPI(ip="127.0.0.1", port="5545", access_token="example")
 
-# Control the miner using JSON RPC
+# Control the miner using JSON RPC.
 x.pause_miner()
 x.resume_miner()
 x.stop_miner()
 x.start_miner()
 
-# Edit and update the miners `config.json` via the HTTP API
+# Edit and update the miners `config.json` via the HTTP API.
 config = x.get_config()
 config["pools"]["USER"] = "NEW_WALLET_ADDRESS"
 x.post_config(config)

--- a/example.py
+++ b/example.py
@@ -1,0 +1,28 @@
+import xmrig, logging
+x = xmrig.XMRigAPI(ip="127.0.0.1", port="5555", access_token="example")
+logging.basicConfig()
+logging.getLogger("XMRigAPI").setLevel(logging.INFO)            # Change to DEBUG to print out all responses when their methods are called
+log = logging.getLogger("MyLOG")
+
+# Control the miner using JSON RPC.
+x.pause_miner()
+x.resume_miner()
+x.stop_miner()
+x.start_miner()
+
+# Update cached data from endpoints individually or all at once
+x.update_summary()
+x.update_all_responses()
+
+# Edit and update the miners `config.json` via the HTTP API.
+x.update_config()                                               # This updates the cached data
+config = x.config()                                             # Use the `config` property to access the data
+config["pools"]["USER"] = "NEW_WALLET_ADDRESS"
+x.post_config(config)
+
+# Summary and Backends API data is available as properties in either full or individual format.
+log.info(x.summary)                                             # Prints the entire `summary` endpoint response
+log.info(x.sum_hashrates)                                       # Prints out the current hashrates
+log.info(x.sum_pool_accepted_jobs)                              # Prints out the accepted_jobs counter
+log.info(x.sum_pool_rejected_jobs)                              # Prints out the rejected_jobs counter
+log.info(x.sum_current_difficulty)                              # Prints out the current difficulty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ requests = "^2.32.3"
 psutil = "^6.0.0"
 
 
+[tool.poetry.group.dev.dependencies]
+twine = "^5.1.1"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xmrig"
-version = "1.1.0"
+version = "1.1.1"
 description = "A python package for easy in line interfacing with XMRig Miner HTTP API"
 authors = ["CoulterStutz <coultercash@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.9"
 requests = "^2.32.3"
+psutil = "^6.0.0"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,12 @@
 name = "xmrig"
 version = "1.1.2"
 description = "A python package for easy in line interfacing with XMRig Miner HTTP API"
-authors = ["CoulterStutz <coultercash@gmail.com>"]
+authors = ["CoulterStutz <coultercash@gmail.com>", "hreikin <hreikin@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
 requests = "^2.32.3"
-psutil = "^6.0.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xmrig"
-version = "1.1.1"
+version = "1.1.2"
 description = "A python package for easy in line interfacing with XMRig Miner HTTP API"
 authors = ["CoulterStutz <coultercash@gmail.com>"]
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2024.8.30
+charset-normalizer==3.4.0
+idna==3.10
+requests==2.32.3
+urllib3==2.2.3

--- a/xmrig/__init__.py
+++ b/xmrig/__init__.py
@@ -1,3 +1,9 @@
+"""
+XMRig module initializer.
+
+This module provides the `XMRigAPI` object to interact with the XMRig miner API.
+"""
+
 __name__ = "xmrig"
 __author__ = "Coulter Stutz"
 __email__ = "coulterstutz@gmail.com"

--- a/xmrig/__init__.py
+++ b/xmrig/__init__.py
@@ -1,7 +1,7 @@
 __name__ = "xmrig"
 __author__ = "Coulter Stutz"
 __email__ = "coulterstutz@gmail.com"
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from .xmrig import XMRigAPI, XMRig, XMRigPool, PoolCoin, PoolAlgorithm
 __all__ = ["XMRig", "XMRigAPI", "XMRigPool", "PoolCoin", "PoolAlgorithm"]

--- a/xmrig/__init__.py
+++ b/xmrig/__init__.py
@@ -7,7 +7,8 @@ This module provides the `XMRigAPI` object to interact with the XMRig miner API.
 __name__ = "xmrig"
 __author__ = "Coulter Stutz"
 __email__ = "coulterstutz@gmail.com"
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
-from .xmrig import XMRigAPI, XMRig, XMRigPool, PoolCoin, PoolAlgorithm
-__all__ = ["XMRig", "XMRigAPI", "XMRigPool", "PoolCoin", "PoolAlgorithm"]
+from .xmrig import XMRigAPI
+
+__all__ = ["XMRigAPI"]

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -106,7 +106,7 @@ class XMRigAPI:
             print(f"An error occurred setting the Authorization Header: {e}")
             return False
 
-    def get_summary(self) -> requests.Response | bool:
+    def get_summary(self) -> requests.Response.json | bool:
         """
         Fetches the summary data from the XMRig API.
 
@@ -125,7 +125,7 @@ class XMRigAPI:
             print(f"An error occurred while connecting to {self._summary_url}: {e}")
             return False
 
-    def get_backends(self) -> requests.Response | bool:
+    def get_backends(self) -> requests.Response.json | bool:
         """
         Fetches the backends data from the XMRig API.
 
@@ -144,7 +144,7 @@ class XMRigAPI:
             print(f"An error occurred while connecting to {self._backends_url}: {e}")
             return False
 
-    def get_config(self) -> requests.Response | bool:
+    def get_config(self) -> requests.Response.json | bool:
         """
         Fetches the config data from the XMRig API.
 

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -109,12 +109,12 @@ class XMRigAPI:
             log.error(f"An error occurred setting the Authorization Header: {e}")
             return False
 
-    def get_summary(self) -> requests.Response.json | bool:
+    def update_summary(self) -> bool:
         """
-        Fetches the summary data from the XMRig API.
+        Updates the cached summary data from the XMRig API.
 
         Returns:
-            dict: Parsed JSON response from the summary endpoint, or False if an error occurred.
+            dict: True if the cached data is successfully updated or False if an error occurred.
         """
         try:
             summary_response = requests.get(
@@ -125,17 +125,17 @@ class XMRigAPI:
             summary_response.raise_for_status()
             self._summary_response = summary_response.json()
             log.info(f"Summary endpoint successfully fetched.")
-            return summary_response.json()
+            return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred while connecting to {self._summary_url}: {e}")
             return False
 
-    def get_backends(self) -> requests.Response.json | bool:
+    def update_backends(self) -> bool:
         """
-        Fetches the backends data from the XMRig API.
+        Updates the cached backends data from the XMRig API.
 
         Returns:
-            dict: Parsed JSON response from the backends endpoint, or False if an error occurred.
+            dict: True if the cached data is successfully updated or False if an error occurred.
         """
         try:
             backends_response = requests.get(
@@ -146,17 +146,17 @@ class XMRigAPI:
             backends_response.raise_for_status()
             self._backends_response = backends_response.json()
             log.info(f"Backends endpoint successfully fetched.")
-            return backends_response.json()
+            return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred while connecting to {self._backends_url}: {e}")
             return False
 
-    def get_config(self) -> requests.Response.json | bool:
+    def update_config(self) -> bool:
         """
-        Fetches the config data from the XMRig API.
+        Updates the cached config data from the XMRig API.
 
         Returns:
-            dict: Parsed JSON response from the config endpoint (GET), or False if an error occurred.
+            dict: True if the cached data is successfully updated, or False if an error occurred.
         """
         try:
             config_response = requests.get(
@@ -167,14 +167,14 @@ class XMRigAPI:
             config_response.raise_for_status()
             self._config_response = config_response.json()
             log.info(f"Config endpoint successfully fetched.")
-            return config_response.json()
+            return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred while connecting to {self._config_url}: {e}")
             return False
 
     def post_config(self, config: dict) -> bool:
         """
-        Updates the config data via the XMRig API.
+        Updates the miners config data via the XMRig API.
 
         Returns:
             bool: True if the config was changed successfully, or False if an error occurred.
@@ -200,10 +200,10 @@ class XMRigAPI:
             bool: True if successfull, or False if an error occurred.
         """
         try:
-            self._summary_response = self.get_summary()
-            self._backends_response = self.get_backends()
+            self.update_summary()
+            self.update_backends()
             if self._access_token != None:
-                self._config_response = self.get_config()
+                self.update_config()
             log.info(f"All endpoints successfully fetched.")
             return True
         except Exception as e:

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -296,6 +296,7 @@ class XMRigAPI:
             dict: Current summary response, or False if not available.
         """
         if self._summary_response:
+            log.debug(self._summary_response)
             return self._summary_response
         log.error(f"An error occurred fetching the cached summary data.")
         return False
@@ -309,6 +310,7 @@ class XMRigAPI:
             dict: Current backends response, or False if not available.
         """
         if self._backends_response:
+            log.debug(self._backends_response)
             return self._backends_response
         log.error(f"An error occurred fetching the cached backends data.")
         return False
@@ -322,6 +324,7 @@ class XMRigAPI:
             dict: Current config response, or False if not available.
         """
         if self._config_response:
+            log.debug(self._config_response)
             return self._config_response
         log.error(f"An error occurred fetching the cached config data.")
         return False
@@ -335,6 +338,7 @@ class XMRigAPI:
             str: ID information, or False if not available.
         """
         if self._summary_response and "id" in self._summary_response:
+            log.debug(self._summary_response["id"])
             return self._summary_response["id"]
         log.error(f"An error occurred fetching the cached ID information data.")
         return False
@@ -348,6 +352,7 @@ class XMRigAPI:
             str: Worker ID information, or False if not available.
         """
         if self._summary_response and "worker_id" in self._summary_response:
+            log.debug(self._summary_response["worker_id"])
             return self._summary_response["worker_id"]
         log.error(f"An error occurred fetching the cached worker ID information data.")
         return False
@@ -361,6 +366,7 @@ class XMRigAPI:
             int: Current uptime in seconds, or False if not available.
         """
         if self._summary_response and "uptime" in self._summary_response:
+            log.debug(self._summary_response["uptime"])
             return self._summary_response["uptime"]
         log.error(f"An error occurred fetching the cached current uptime data.")
         return False
@@ -374,6 +380,7 @@ class XMRigAPI:
             str: Uptime in the format "days, hours:minutes:seconds", or False if not available.
         """
         if self._summary_response and "uptime" in self._summary_response:
+            log.debug(str(timedelta(seconds=self._summary_response["uptime"])))
             return str(timedelta(seconds=self._summary_response["uptime"]))
         log.error(f"An error occurred fetching the cached current uptime in a human-readable format data.")
         return False
@@ -387,6 +394,7 @@ class XMRigAPI:
             bool: Current restricted status, or None if not available.
         """
         if self._summary_response and "restricted" in self._summary_response:
+            log.debug(self._summary_response["restricted"])
             return self._summary_response["restricted"]
         log.error(f"An error occurred fetching the cached restricted status data.")
         return None
@@ -400,6 +408,7 @@ class XMRigAPI:
             dict: Resources information, or False if not available.
         """
         if self._summary_response and "resources" in self._summary_response:
+            log.debug(self._summary_response["resources"])
             return self._summary_response["resources"]
         log.error(f"An error occurred fetching the cached resources data.")
         return False
@@ -413,6 +422,7 @@ class XMRigAPI:
             dict: Memory usage information, or False if not available.
         """
         if self._summary_response and "memory" in self._summary_response["resources"]:
+            log.debug(self._summary_response["resources"]["memory"])
             return self._summary_response["resources"]["memory"]
         log.error(f"An error occurred fetching the cached memory usage data.")
         return False
@@ -426,6 +436,7 @@ class XMRigAPI:
             int: Free memory information, or False if not available.
         """
         if self._summary_response and "free" in self._summary_response["resources"]["memory"]:
+            log.debug(self._summary_response["resources"]["memory"]["free"])
             return self._summary_response["resources"]["memory"]["free"]
         log.error(f"An error occurred fetching the cached free memory data.")
         return False
@@ -439,6 +450,7 @@ class XMRigAPI:
             int: Total memory information, or False if not available.
         """
         if self._summary_response and "total" in self._summary_response["resources"]["memory"]:
+            log.debug(self._summary_response["resources"]["memory"]["total"])
             return self._summary_response["resources"]["memory"]["total"]
         log.error(f"An error occurred fetching the cached total memory data.")
         return False
@@ -452,6 +464,7 @@ class XMRigAPI:
             int: Resident set memory information, or False if not available.
         """
         if self._summary_response and "resident_set" in self._summary_response["resources"]["memory"]:
+            log.debug(self._summary_response["resources"]["memory"]["resident_set_memory"])
             return self._summary_response["resources"]["memory"]["resident_set_memory"]
         log.error(f"An error occurred fetching the cached resident set memory data.")
         return False
@@ -465,6 +478,7 @@ class XMRigAPI:
             list: Load average information, or False if not available.
         """
         if self._summary_response and "load_average" in self._summary_response["resources"]:
+            log.debug(self._summary_response["resources"]["load_average"])
             return self._summary_response["resources"]["load_average"]
         log.error(f"An error occurred fetching the cached load average data.")
         return False
@@ -478,6 +492,7 @@ class XMRigAPI:
             int: Hardware concurrency information, or False if not available.
         """
         if self._summary_response and "hardware_concurrency" in self._summary_response["resources"]:
+            log.debug(self._summary_response["resources"]["hardware_concurrency"])
             return self._summary_response["resources"]["hardware_concurrency"]
         log.error(f"An error occurred fetching the cached hardware concurrency data.")
         return False
@@ -491,6 +506,7 @@ class XMRigAPI:
             list: Supported features information, or False if not available.
         """
         if self._summary_response and "features" in self._summary_response["resources"]:
+            log.debug(self._summary_response["resources"]["features"])
             return self._summary_response["resources"]["features"]
         log.error(f"An error occurred fetching the cached features data.")
         return False
@@ -504,6 +520,7 @@ class XMRigAPI:
             dict: Results information, or False if not available.
         """
         if self._summary_response and "results" in self._summary_response:
+            log.debug(self._summary_response["results"])
             return self._summary_response["results"]
         log.error(f"An error occurred fetching the cached results data.")
         return False
@@ -517,6 +534,7 @@ class XMRigAPI:
             int: Current difficulty, or False if not available.
         """
         if self._summary_response and "results" in self._summary_response:
+            log.debug(self._summary_response["results"]["diff_current"])
             return self._summary_response["results"]["diff_current"]
         log.error(f"An error occurred fetching the cached current difficulty data.")
         return False
@@ -530,6 +548,7 @@ class XMRigAPI:
             int: Good shares, or False if not available.
         """
         if self._summary_response and "results" in self._summary_response:
+            log.debug(self._summary_response["results"]["shares_good"])
             return self._summary_response["results"]["shares_good"]
         log.error(f"An error occurred fetching the cached good shares data.")
         return False
@@ -543,6 +562,7 @@ class XMRigAPI:
             int: Total shares, or False if not available.
         """
         if self._summary_response and "results" in self._summary_response:
+            log.debug(self._summary_response["results"]["shares_total"])
             return self._summary_response["results"]["shares_total"]
         log.error(f"An error occurred fetching the cached total shares data.")
         return False
@@ -556,6 +576,7 @@ class XMRigAPI:
             int: Average time information, or False if not available.
         """
         if self._summary_response and "results" in self._summary_response:
+            log.debug(self._summary_response["results"]["avg_time"])
             return self._summary_response["results"]["avg_time"]
         log.error(f"An error occurred fetching the cached average time data.")
         return False
@@ -569,6 +590,7 @@ class XMRigAPI:
             int: Average time in `ms` information, or False if not available.
         """
         if self._summary_response and "results" in self._summary_response:
+            log.debug(self._summary_response["results"]["avg_time_ms"])
             return self._summary_response["results"]["avg_time_ms"]
         log.error(f"An error occurred fetching the cached average time in `ms` data.")
         return False
@@ -582,6 +604,7 @@ class XMRigAPI:
             int: Total number of hashes, or False if not available.
         """
         if self._summary_response and "results" in self._summary_response:
+            log.debug(self._summary_response["results"]["hashes_total"])
             return self._summary_response["results"]["hashes_total"]
         log.error(f"An error occurred fetching the cached total hashes data.")
         return False
@@ -595,6 +618,7 @@ class XMRigAPI:
             list: Best results, or False if not available.
         """
         if self._summary_response and "results" in self._summary_response:
+            log.debug(self._summary_response["results"]["best"])
             return self._summary_response["results"]["best"]
         log.error(f"An error occurred fetching the cached best results data.")
         return False
@@ -608,6 +632,7 @@ class XMRigAPI:
             str: Current mining algorithm, or False if not available.
         """
         if self._summary_response and "algo" in self._summary_response:
+            log.debug(self._summary_response["algo"])
             return self._summary_response["algo"]
         log.error(f"An error occurred fetching the cached current mining alogorithm data.")
         return False
@@ -621,6 +646,7 @@ class XMRigAPI:
             dict: Connection information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"])
             return self._summary_response["connection"]
         log.error(f"An error occurred fetching the cached connection data.")
         return False
@@ -634,6 +660,7 @@ class XMRigAPI:
             str: Pool information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["pool"])
             return self._summary_response["connection"]["pool"]
         log.error(f"An error occurred fetching the cached pool information data.")
         return False
@@ -647,6 +674,7 @@ class XMRigAPI:
             str: IP address, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["ip"])
             return self._summary_response["connection"]["ip"]
         log.error(f"An error occurred fetching the cached IP address data.")
         return False
@@ -660,6 +688,7 @@ class XMRigAPI:
             int: Pool uptime information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["uptime"])
             return self._summary_response["connection"]["uptime"]
         log.error(f"An error occurred fetching the cached pool uptime data.")
         return False
@@ -673,6 +702,7 @@ class XMRigAPI:
             int: Pool uptime in ms, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["uptime_ms"])
             return self._summary_response["connection"]["uptime_ms"]
         log.error(f"An error occurred fetching the cached pool uptime in `ms` data.")
         return False
@@ -686,6 +716,7 @@ class XMRigAPI:
             int: Pool ping information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["ping"])
             return self._summary_response["connection"]["ping"]
         log.error(f"An error occurred fetching the cached pool ping data.")
         return False
@@ -699,6 +730,7 @@ class XMRigAPI:
             int: Pool failures information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["failures"])
             return self._summary_response["connection"]["failures"]
         log.error(f"An error occurred fetching the cached pool failures data.")
         return False
@@ -712,6 +744,7 @@ class XMRigAPI:
             bool: Pool tls status, or None if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["tls"])
             return self._summary_response["connection"]["tls"]
         log.error(f"An error occurred fetching the cached pool tls data.")
         return None
@@ -725,6 +758,7 @@ class XMRigAPI:
             str: Pool tls fingerprint information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["tls-fingerprint"])
             return self._summary_response["connection"]["tls-fingerprint"]
         log.error(f"An error occurred fetching the cached pool tls fingerprint data.")
         return False
@@ -738,6 +772,7 @@ class XMRigAPI:
             str: Pool algorithm information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["algo"])
             return self._summary_response["connection"]["algo"]
         log.error(f"An error occurred fetching the cached pool algorithm data.")
         return False
@@ -751,6 +786,7 @@ class XMRigAPI:
             int: Pool difficulty information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["diff"])
             return self._summary_response["connection"]["diff"]
         log.error(f"An error occurred fetching the cached pool difficulty data.")
         return False
@@ -764,6 +800,7 @@ class XMRigAPI:
             int: Number of accepted jobs, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["accepted"])
             return self._summary_response["connection"]["accepted"]
         log.error(f"An error occurred fetching the cached pool accepted jobs data.")
         return False
@@ -777,6 +814,7 @@ class XMRigAPI:
             int: Number of rejected jobs, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["rejected"])
             return self._summary_response["connection"]["rejected"]
         log.error(f"An error occurred fetching the cached pool rejected jobs data.")
         return False
@@ -790,6 +828,7 @@ class XMRigAPI:
             int: Pool average time information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["avg_time"])
             return self._summary_response["connection"]["avg_time"]
         log.error(f"An error occurred fetching the cached pool average time data.")
         return False
@@ -803,6 +842,7 @@ class XMRigAPI:
             int: Pool average in ms, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["avg_time_ms"])
             return self._summary_response["connection"]["avg_time_ms"]
         log.error(f"An error occurred fetching the cached pool average time in `ms` data.")
         return False
@@ -816,6 +856,7 @@ class XMRigAPI:
             int: Pool total hashes information, or False if not available.
         """
         if self._summary_response and "connection" in self._summary_response:
+            log.debug(self._summary_response["connection"]["hashes_total"])
             return self._summary_response["connection"]["hashes_total"]
         log.error(f"An error occurred fetching the cached pool total hashes data.")
         return False
@@ -829,6 +870,7 @@ class XMRigAPI:
             str: Version information, or False if not available.
         """
         if self._summary_response and "version" in self._summary_response:
+            log.debug(self._summary_response["version"])
             return self._summary_response["version"]
         log.error(f"An error occurred fetching the cached version data.")
         return False
@@ -842,6 +884,7 @@ class XMRigAPI:
             str: Kind information, or False if not available.
         """
         if self._summary_response and "kind" in self._summary_response:
+            log.debug(self._summary_response["kind"])
             return self._summary_response["kind"]
         log.error(f"An error occurred fetching the cached kind data.")
         return False
@@ -855,6 +898,7 @@ class XMRigAPI:
             str: User agent information, or False if not available.
         """
         if self._summary_response and "ua" in self._summary_response:
+            log.debug(self._summary_response["ua"])
             return self._summary_response["ua"]
         log.error(f"An error occurred fetching the cached user agent data.")
         return False
@@ -868,6 +912,7 @@ class XMRigAPI:
             dict: CPU information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"])
             return self._summary_response["cpu"]
         log.error(f"An error occurred fetching the cached CPU data.")
         return False
@@ -881,6 +926,7 @@ class XMRigAPI:
             str: CPU brand information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["brand"])
             return self._summary_response["cpu"]["brand"]
         log.error(f"An error occurred fetching the cached CPU brand data.")
         return False
@@ -894,6 +940,7 @@ class XMRigAPI:
             int: CPU family information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["family"])
             return self._summary_response["cpu"]["family"]
         log.error(f"An error occurred fetching the cached CPU family data.")
         return False
@@ -907,6 +954,7 @@ class XMRigAPI:
             int: CPU model information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["model"])
             return self._summary_response["cpu"]["model"]
         log.error(f"An error occurred fetching the cached CPU model data.")
         return False
@@ -920,6 +968,7 @@ class XMRigAPI:
             int: CPU stepping information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["stepping"])
             return self._summary_response["cpu"]["stepping"]
         log.error(f"An error occurred fetching the cached CPU stepping data.")
         return False
@@ -933,6 +982,7 @@ class XMRigAPI:
             int: CPU frequency information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["proc_info"])
             return self._summary_response["cpu"]["proc_info"]
         log.error(f"An error occurred fetching the cached CPU frequency data.")
         return False
@@ -946,6 +996,7 @@ class XMRigAPI:
             int: CPU aes information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["aes"])
             return self._summary_response["cpu"]["aes"]
         log.error(f"An error occurred fetching the cached CPU aes data.")
         return False
@@ -959,6 +1010,7 @@ class XMRigAPI:
             int: CPU avx2 information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["avx2"])
             return self._summary_response["cpu"]["avx2"]
         log.error(f"An error occurred fetching the cached CPU avx2 data.")
         return False
@@ -972,6 +1024,7 @@ class XMRigAPI:
             int: CPU x64 information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["x64"])
             return self._summary_response["cpu"]["x64"]
         log.error(f"An error occurred fetching the cached CPU x64 data.")
         return False
@@ -985,6 +1038,7 @@ class XMRigAPI:
             int: CPU 64-bit information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["64_bit"])
             return self._summary_response["cpu"]["64_bit"]
         log.error(f"An error occurred fetching the cached CPU x64-bit data.")
         return False
@@ -998,6 +1052,7 @@ class XMRigAPI:
             int: CPU l2 cache information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["l2"])
             return self._summary_response["cpu"]["l2"]
         log.error(f"An error occurred fetching the cached CPU l2 cache data.")
         return False
@@ -1011,6 +1066,7 @@ class XMRigAPI:
             int: CPU l3 cache information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["l3"])
             return self._summary_response["cpu"]["l3"]
         log.error(f"An error occurred fetching the cached CPU l3 cache data.")
         return False
@@ -1024,6 +1080,7 @@ class XMRigAPI:
             int: CPU cores information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["cores"])
             return self._summary_response["cpu"]["cores"]
         log.error(f"An error occurred fetching the cached CPU cores data.")
         return False
@@ -1037,6 +1094,7 @@ class XMRigAPI:
             int: CPU threads information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["threads"])
             return self._summary_response["cpu"]["threads"]
         log.error(f"An error occurred fetching the cached CPU threads data.")
         return False
@@ -1050,6 +1108,7 @@ class XMRigAPI:
             int: CPU packages information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["packages"])
             return self._summary_response["cpu"]["packages"]
         log.error(f"An error occurred fetching the cached CPU packages data.")
         return False
@@ -1063,6 +1122,7 @@ class XMRigAPI:
             int: CPU nodes information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["nodes"])
             return self._summary_response["cpu"]["nodes"]
         log.error(f"An error occurred fetching the cached CPU nodes data.")
         return False
@@ -1076,6 +1136,7 @@ class XMRigAPI:
             str: CPU backend information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["backend"])
             return self._summary_response["cpu"]["backend"]
         log.error(f"An error occurred fetching the cached CPU backend data.")
         return False
@@ -1089,6 +1150,7 @@ class XMRigAPI:
             str: CPU msr information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["msr"])
             return self._summary_response["cpu"]["msr"]
         log.error(f"An error occurred fetching the cached CPU msr data.")
         return False
@@ -1102,6 +1164,7 @@ class XMRigAPI:
             str: CPU assembly information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["assembly"])
             return self._summary_response["cpu"]["assembly"]
         log.error(f"An error occurred fetching the cached CPU assembly data.")
         return False
@@ -1115,6 +1178,7 @@ class XMRigAPI:
             str: CPU architecture information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["arch"])
             return self._summary_response["cpu"]["arch"]
         log.error(f"An error occurred fetching the cached CPU architecture data.")
         return False
@@ -1128,6 +1192,7 @@ class XMRigAPI:
             list: CPU flags information, or False if not available.
         """
         if self._summary_response and "cpu" in self._summary_response:
+            log.debug(self._summary_response["cpu"]["flags"])
             return self._summary_response["cpu"]["flags"]
         log.error(f"An error occurred fetching the cached CPU flags data.")
         return False
@@ -1141,6 +1206,7 @@ class XMRigAPI:
             int: Donation level information, or False if not available.
         """
         if self._summary_response and "donate_level" in self._summary_response:
+            log.debug(self._summary_response["donate_level"])
             return self._summary_response["donate_level"]
         log.error(f"An error occurred fetching the cached donation level data.")
         return False
@@ -1154,6 +1220,7 @@ class XMRigAPI:
             int: True if the miner is paused, False otherwise, or False if not available.
         """
         if self._summary_response and "paused" in self._summary_response:
+            log.debug(self._summary_response["paused"])
             return self._summary_response["paused"]
         log.error(f"An error occurred fetching the cached paused status data.")
         return False
@@ -1167,6 +1234,7 @@ class XMRigAPI:
             list: Algorithms information, or False if not available.
         """
         if self._summary_response and "algorithms" in self._summary_response:
+            log.debug(self._summary_response["algorithms"])
             return self._summary_response["algorithms"]
         log.error(f"An error occurred fetching the cached algorithms data.")
         return False
@@ -1180,6 +1248,7 @@ class XMRigAPI:
             dict: Current hashrates, or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._summary_response["hashrate"])
             return self._summary_response["hashrate"]
         log.error(f"An error occurred fetching the cached current hashrates data.")
         return False
@@ -1193,6 +1262,7 @@ class XMRigAPI:
             int: Current hashrate (10s), or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._summary_response["hashrate"]["total"][0])
             return self._summary_response["hashrate"]["total"][0]
         log.error(f"An error occurred fetching the cached current hashrate (10s) data.")
         return False
@@ -1206,6 +1276,7 @@ class XMRigAPI:
             int: Current hashrate (1m), or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._summary_response["hashrate"]["total"][1])
             return self._summary_response["hashrate"]["total"][1]
         log.error(f"An error occurred fetching the cached current hashrate (1m) data.")
         return False
@@ -1219,6 +1290,7 @@ class XMRigAPI:
             int: Current hashrate (15m), or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._summary_response["hashrate"]["total"][2])
             return self._summary_response["hashrate"]["total"][2]
         log.error(f"An error occurred fetching the cached current hashrate (15m) data.")
         return False
@@ -1232,6 +1304,7 @@ class XMRigAPI:
             int: Current hashrate (highest), or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._summary_response["hashrate"]["highest"])
             return self._summary_response["hashrate"]["highest"]
         log.error(f"An error occurred fetching the cached highest hashrate data.")
         return False
@@ -1245,6 +1318,7 @@ class XMRigAPI:
             list: Current hugepages, or False if not available.
         """
         if self._summary_response and "hugepages" in self._summary_response:
+            log.debug(self._summary_response["hugepages"])
             return self._summary_response["hugepages"]
         log.error(f"An error occurred fetching the cached hugepages data.")
         return False
@@ -1263,6 +1337,7 @@ class XMRigAPI:
             for i in self._backends_response:
                 if "type" in i and i["enabled"] == True:
                     backend_types.append(i["type"])
+            log.debug(backend_types)
             return backend_types
         log.error(f"An error occurred fetching the cached enabled backends data.")
         return False
@@ -1276,6 +1351,7 @@ class XMRigAPI:
             bool: Bool representing enabled status, or None if not available.
         """
         if self._backends_response and "enabled" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["enabled"])
             return self._backends_response[0]["enabled"]
         log.error(f"An error occurred fetching the cached CPU enabled status data.")
         return None
@@ -1289,6 +1365,7 @@ class XMRigAPI:
             str: Bool representing algorithm information, or False if not available.
         """
         if self._backends_response and "algo" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["algo"])
             return self._backends_response[0]["algo"]
         log.error(f"An error occurred fetching the cached CPU algorithm data.")
         return False
@@ -1302,6 +1379,7 @@ class XMRigAPI:
             str: Bool representing profile information, or False if not available.
         """
         if self._backends_response and "profile" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["profile"])
             return self._backends_response[0]["profile"]
         log.error(f"An error occurred fetching the cached CPU profile data.")
         return False
@@ -1315,6 +1393,7 @@ class XMRigAPI:
             bool: Bool representing hw-aes support status, or None if not available.
         """
         if self._backends_response and "hw-aes" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["hw-aes"])
             return self._backends_response[0]["hw-aes"]
         log.error(f"An error occurred fetching the cached CPU hw-aes support data.")
         return None
@@ -1331,6 +1410,7 @@ class XMRigAPI:
             int: Int representing mining thread priority, or False if not available.
         """
         if self._backends_response and "priority" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["priority"])
             return self._backends_response[0]["priority"]
         log.error(f"An error occurred fetching the cached CPU priority data.")
         return False
@@ -1344,6 +1424,7 @@ class XMRigAPI:
             bool: Bool representing msr information, or None if not available.
         """
         if self._backends_response and "msr" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["msr"])
             return self._backends_response[0]["msr"]
         log.error(f"An error occurred fetching the cached CPU msr data.")
         return None
@@ -1357,6 +1438,7 @@ class XMRigAPI:
             str: Bool representing asm information, or False if not available.
         """
         if self._backends_response and "asm" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["asm"])
             return self._backends_response[0]["asm"]
         log.error(f"An error occurred fetching the cached CPU asm data.")
         return False
@@ -1370,6 +1452,7 @@ class XMRigAPI:
             str: Bool representing argon2 implementation information, or False if not available.
         """
         if self._backends_response and "argon2-impl" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["argon2-impl"])
             return self._backends_response[0]["argon2-impl"]
         log.error(f"An error occurred fetching the cached CPU argon2 implementation data.")
         return False
@@ -1383,6 +1466,7 @@ class XMRigAPI:
             list: Bool representing hugepages information, or False if not available.
         """
         if self._backends_response and "hugepages" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["hugepages"])
             return self._backends_response[0]["hugepages"]
         log.error(f"An error occurred fetching the cached CPU hugepages data.")
         return False
@@ -1396,6 +1480,7 @@ class XMRigAPI:
             int: Bool representing memory information, or False if not available.
         """
         if self._backends_response and "memory" in self._backends_response[0]:
+            log.debug(self._backends_response[0]["memory"])
             return self._backends_response[0]["memory"]
         log.error(f"An error occurred fetching the cached CPU memory data.")
         return False
@@ -1409,6 +1494,7 @@ class XMRigAPI:
             bool: Bool representing enabled information, or None if not available.
         """
         if self._backends_response and "enabled" in self._backends_response[1]:
+            log.debug(self._backends_response[1]["enabled"])
             return self._backends_response[1]["enabled"]
         log.error(f"An error occurred fetching the cached OpenCL enabled data.")
         return None
@@ -1422,6 +1508,7 @@ class XMRigAPI:
             str: Bool representing algorithm information, or False if not available.
         """
         if self._backends_response and "algo" in self._backends_response[1]:
+            log.debug(self._backends_response[1]["algo"])
             return self._backends_response[1]["algo"]
         log.error(f"An error occurred fetching the cached OpenCL algorithm data.")
         return False
@@ -1435,6 +1522,7 @@ class XMRigAPI:
             str: Bool representing profile information, or False if not available.
         """
         if self._backends_response and "profile" in self._backends_response[1]:
+            log.debug(self._backends_response[1]["profile"])
             return self._backends_response[1]["profile"]
         log.error(f"An error occurred fetching the cached OpenCL profile data.")
         return False
@@ -1448,6 +1536,7 @@ class XMRigAPI:
             str: Bool representing platform information, or False if not available.
         """
         if self._backends_response and "platform" in self._backends_response[1]:
+            log.debug(self._backends_response[1]["platform"])
             return self._backends_response[1]["platform"]
         log.error(f"An error occurred fetching the cached OpenCL platform data.")
         return False
@@ -1461,6 +1550,7 @@ class XMRigAPI:
             str: Current type info, or False if not available.
         """
         if self._backends_response and "type" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["type"])
             return self._backends_response[2]["type"]
         log.error(f"An error occurred fetching the cached Cuda type data.")
         return False
@@ -1474,6 +1564,7 @@ class XMRigAPI:
             bool: Current enabled info, or None if not available.
         """
         if self._backends_response and "enabled" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["enabled"])
             return self._backends_response[2]["enabled"]
         log.error(f"An error occurred fetching the cached Cuda enabled status data.")
         return None
@@ -1487,6 +1578,7 @@ class XMRigAPI:
             str: Bool representing algorithm information, or False if not available.
         """
         if self._backends_response and "algo" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["algo"])
             return self._backends_response[2]["algo"]
         log.error(f"An error occurred fetching the cached Cuda algorithm data.")
         return False
@@ -1500,6 +1592,7 @@ class XMRigAPI:
             str: Bool representing profile information, or False if not available.
         """
         if self._backends_response and "profile" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["profile"])
             return self._backends_response[2]["profile"]
         log.error(f"An error occurred fetching the cached Cuda profile data.")
         return False
@@ -1513,6 +1606,7 @@ class XMRigAPI:
             dict: Bool representing versions information, or False if not available.
         """
         if self._backends_response and "versions" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["versions"])
             return self._backends_response[2]["versions"]
         log.error(f"An error occurred fetching the cached Cuda versions data.")
         return False
@@ -1526,6 +1620,7 @@ class XMRigAPI:
            str: Bool representing cuda runtime information, or False if not available.
         """
         if self._backends_response and "cuda-runtime" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["versions"]["cuda-runtime"])
             return self._backends_response[2]["versions"]["cuda-runtime"]
         log.error(f"An error occurred fetching the cached Cuda runtime data.")
         return False
@@ -1539,6 +1634,7 @@ class XMRigAPI:
             str: Bool representing cuda driver information, or False if not available.
         """
         if self._backends_response and "cuda-driver" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["versions"]["cuda-driver"])
             return self._backends_response[2]["versions"]["cuda-driver"]
         log.error(f"An error occurred fetching the cached Cuda driver data.")
         return False
@@ -1552,6 +1648,7 @@ class XMRigAPI:
             str: Bool representing cuda plugin information, or False if not available.
         """
         if self._backends_response and "plugin" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["versions"]["plugin"])
             return self._backends_response[2]["versions"]["plugin"]
         log.error(f"An error occurred fetching the cached Cuda plugin data.")
         return False
@@ -1565,6 +1662,7 @@ class XMRigAPI:
             list: Current hashrate info, or False if not available.
         """
         if self._backends_response and "hashrate" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["hashrate"])
             return self._backends_response[2]["hashrate"]
         log.error(f"An error occurred fetching the cached Cuda current hashrate data.")
         return False
@@ -1578,6 +1676,7 @@ class XMRigAPI:
            int: Current hashrate (10s) info, or False if not available.
         """
         if self._backends_response and "hashrate" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["hashrate"][0])
             return self._backends_response[2]["hashrate"][0]
         log.error(f"An error occurred fetching the cached Cuda current hashrate (10s) data.")
         return False
@@ -1591,6 +1690,7 @@ class XMRigAPI:
             int: Current hashrate (1m) info, or False if not available.
         """
         if self._backends_response and "hashrate" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["hashrate"][1])
             return self._backends_response[2]["hashrate"][1]
         log.error(f"An error occurred fetching the cached Cuda current hashrate (1m) data.")
         return False
@@ -1604,6 +1704,7 @@ class XMRigAPI:
             int: Current hashrate (15m) info, or False if not available.
         """
         if self._backends_response and "hashrate" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["hashrate"][2])
             return self._backends_response[2]["hashrate"][2]
         log.error(f"An error occurred fetching the cached Cuda current hashrate (15m) data.")
         return False
@@ -1617,6 +1718,7 @@ class XMRigAPI:
             dict: Current threads info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0])
             return self._backends_response[2]["threads"][0]
         log.error(f"An error occurred fetching the cached Cuda threads data.")
         return False
@@ -1630,6 +1732,7 @@ class XMRigAPI:
             int: Current threads index info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["index"])
             return self._backends_response[2]["threads"][0]["index"]
         log.error(f"An error occurred fetching the cached Cuda threads index data.")
         return False
@@ -1643,6 +1746,7 @@ class XMRigAPI:
             int: Current threads amount info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["threads"])
             return self._backends_response[2]["threads"][0]["threads"]
         log.error(f"An error occurred fetching the cached Cuda threads amount data.")
         return False
@@ -1656,6 +1760,7 @@ class XMRigAPI:
             int: Current threads blocks info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["blocks"])
             return self._backends_response[2]["threads"][0]["blocks"]
         log.error(f"An error occurred fetching the cached Cuda threads blocks data.")
         return False
@@ -1669,6 +1774,7 @@ class XMRigAPI:
             int: Current threads bfactor info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["bfactor"])
             return self._backends_response[2]["threads"][0]["bfactor"]
         log.error(f"An error occurred fetching the cached Cuda threads bfactor data.")
         return False
@@ -1682,6 +1788,7 @@ class XMRigAPI:
             int: Current threads bsleep info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["bsleep"])
             return self._backends_response[2]["threads"][0]["bsleep"]
         log.error(f"An error occurred fetching the cached Cuda threads bsleep data.")
         return False
@@ -1695,6 +1802,7 @@ class XMRigAPI:
             int: Current threads affinity info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["affinity"])
             return self._backends_response[2]["threads"][0]["affinity"]
         log.error(f"An error occurred fetching the cached Cuda threads affinity data.")
         return False
@@ -1708,6 +1816,7 @@ class XMRigAPI:
             bool: Current threads dataset host info, or None if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["dataset_host"])
             return self._backends_response[2]["threads"][0]["dataset_host"]
         log.error(f"An error occurred fetching the cached Cuda threads dataset host data.")
         return None
@@ -1721,6 +1830,7 @@ class XMRigAPI:
             list: Current hashrates, or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._backends_response[2]["threads"][0]["hashrate"])
             return self._backends_response[2]["threads"][0]["hashrate"]
         log.error(f"An error occurred fetching the cached Cuda threads hashrates data.")
         return False
@@ -1734,6 +1844,7 @@ class XMRigAPI:
             int: Current hashrate (10s), or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._backends_response[2]["threads"][0]["hashrate"][0])
             return self._backends_response[2]["threads"][0]["hashrate"][0]
         log.error(f"An error occurred fetching the cached Cuda threads hashrate (10s) data.")
         return False
@@ -1747,6 +1858,7 @@ class XMRigAPI:
             int: Current hashrate (1m), or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._backends_response[2]["threads"][0]["hashrate"][1])
             return self._backends_response[2]["threads"][0]["hashrate"][1]
         log.error(f"An error occurred fetching the cached Cuda threads hashrates (1m) data.")
         return False
@@ -1760,6 +1872,7 @@ class XMRigAPI:
             int: Current hashrate (15m), or False if not available.
         """
         if self._summary_response and "hashrate" in self._summary_response:
+            log.debug(self._backends_response[2]["threads"][0]["hashrate"][2])
             return self._backends_response[2]["threads"][0]["hashrate"][2]
         log.error(f"An error occurred fetching the cached Cuda threads hashrates (15m) data.")
         return False
@@ -1773,6 +1886,7 @@ class XMRigAPI:
             str: Current threads name info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["name"])
             return self._backends_response[2]["threads"][0]["name"]
         log.error(f"An error occurred fetching the cached Cuda threads name data.")
         return False
@@ -1786,6 +1900,7 @@ class XMRigAPI:
             str: Current threads bus ID info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["bus_id"])
             return self._backends_response[2]["threads"][0]["bus_id"]
         log.error(f"An error occurred fetching the cached Cuda threads bus ID data.")
         return False
@@ -1799,6 +1914,7 @@ class XMRigAPI:
             int: Current threads smx info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["smx"])
             return self._backends_response[2]["threads"][0]["smx"]
         log.error(f"An error occurred fetching the cached Cuda threads smx data.")
         return False
@@ -1812,6 +1928,7 @@ class XMRigAPI:
             int: Current threads arch info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["arch"])
             return self._backends_response[2]["threads"][0]["arch"]
         log.error(f"An error occurred fetching the cached Cuda threads arch data.")
         return False
@@ -1825,6 +1942,7 @@ class XMRigAPI:
             int: Current threads global mem info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["global_mem"])
             return self._backends_response[2]["threads"][0]["global_mem"]
         log.error(f"An error occurred fetching the cached Cuda threads global memory data.")
         return False
@@ -1838,6 +1956,7 @@ class XMRigAPI:
             int: Current threads clock info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["clock"])
             return self._backends_response[2]["threads"][0]["clock"]
         log.error(f"An error occurred fetching the cached Cuda threads clock info data.")
         return False
@@ -1851,6 +1970,7 @@ class XMRigAPI:
             int: Current threads memory_clock info, or False if not available.
         """
         if self._backends_response and "threads" in self._backends_response[2]:
+            log.debug(self._backends_response[2]["threads"][0]["memory_clock"])
             return self._backends_response[2]["threads"][0]["memory_clock"]
         log.error(f"An error occurred fetching the cached Cuda threads memory clock data.")
         return False

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -91,7 +91,7 @@ class XMRigAPI:
             "jsonrpc": "2.0",
             "id": 1,
         }
-        self.get_all_responses()
+        self.update_all_responses()
         log.info("XMRigAPI initialized.")
 
     def _set_auth_header(self) -> bool:
@@ -192,7 +192,7 @@ class XMRigAPI:
             log.error(f"An error occurred while connecting to {self._config_url}: {e}")
             return False
 
-    def get_all_responses(self) -> bool:
+    def update_all_responses(self) -> bool:
         """
         Retrieves all responses from the API.
 
@@ -279,16 +279,13 @@ class XMRigAPI:
             bool: True if the miner was successfully started, or False if an error occurred.
         """
         try:
-            self.get_config()
+            self.update_config()
             self.post_config()
             log.info(f"Miner successfully started.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred starting the miner: {e}")
             return False
-    
-    # TODO: Add logging to example in README
-    # TODO: Add try/except blocks with log.debug inside try block for returned cached data
 
     @property
     def summary(self) -> dict |bool:
@@ -1261,12 +1258,12 @@ class XMRigAPI:
         Returns:
             list: List of enabled backends, or False if not available.
         """
-        types = []
+        backend_types = []
         if self._backends_response:
             for i in self._backends_response:
                 if "type" in i and i["enabled"] == True:
-                    types.append(i["type"])
-            return types
+                    backend_types.append(i["type"])
+            return backend_types
         log.error(f"An error occurred fetching the cached enabled backends data.")
         return False
 

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -96,8 +96,12 @@ class XMRig:
 
             if self._http_api_token is not None:
                 self.API = XMRigAPI("127.0.0.1", self._http_api_port, self._http_api_token)
+                self._api_enabled = True
             else:
                 self.API = XMRigAPI("127.0.0.1", self._http_api_port)
+                self._api_enabled = True
+        else:
+            self._api_enabled = False
 
         for x in pools:
             if type(x) is not XMRigPool:
@@ -146,8 +150,11 @@ class XMRig:
             print("xmrig process terminated successfully.")
 
     def restart_xmrig(self):
-        if self._http_api_token is not None:
+        if self._api_enabled:
             self.API.restart_miner()
+        else:
+            self.start_xmrig()
+            self.start_xmrig()
 
 
 class XMRigAPI:

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -288,18 +288,19 @@ class XMRigAPI:
             return False
 
     @property
-    def summary(self) -> dict |bool:
+    def summary(self) -> dict | bool:
         """
         Retrieves the entire cached summary endpoint data.
 
         Returns:
             dict: Current summary response, or False if not available.
         """
-        if self._summary_response:
+        try:
             log.debug(self._summary_response)
             return self._summary_response
-        log.error(f"An error occurred fetching the cached summary data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached summary data: {e}")
+            return False
 
     @property
     def backends(self) -> dict | bool:
@@ -309,11 +310,12 @@ class XMRigAPI:
         Returns:
             dict: Current backends response, or False if not available.
         """
-        if self._backends_response:
+        try:
             log.debug(self._backends_response)
             return self._backends_response
-        log.error(f"An error occurred fetching the cached backends data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached backends data: {e}")
+            return False
 
     @property
     def config(self) -> dict | bool:
@@ -323,11 +325,14 @@ class XMRigAPI:
         Returns:
             dict: Current config response, or False if not available.
         """
-        if self._config_response:
+        try:
             log.debug(self._config_response)
             return self._config_response
-        log.error(f"An error occurred fetching the cached config data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached config data: {e}")
+            return False
+
+    # ***** data provided by summary endpoint
 
     @property
     def sum_id(self) -> str | bool:
@@ -337,11 +342,12 @@ class XMRigAPI:
         Returns:
             str: ID information, or False if not available.
         """
-        if self._summary_response and "id" in self._summary_response:
+        try:
             log.debug(self._summary_response["id"])
             return self._summary_response["id"]
-        log.error(f"An error occurred fetching the cached ID information data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached ID information data: {e}")
+            return False
 
     @property
     def sum_worker_id(self) -> str | bool:
@@ -351,11 +357,12 @@ class XMRigAPI:
         Returns:
             str: Worker ID information, or False if not available.
         """
-        if self._summary_response and "worker_id" in self._summary_response:
+        try:
             log.debug(self._summary_response["worker_id"])
             return self._summary_response["worker_id"]
-        log.error(f"An error occurred fetching the cached worker ID information data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached worker ID information data: {e}")
+            return False
 
     @property
     def sum_uptime(self) -> int | bool:
@@ -365,11 +372,12 @@ class XMRigAPI:
         Returns:
             int: Current uptime in seconds, or False if not available.
         """
-        if self._summary_response and "uptime" in self._summary_response:
+        try:
             log.debug(self._summary_response["uptime"])
             return self._summary_response["uptime"]
-        log.error(f"An error occurred fetching the cached current uptime data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached current uptime data: {e}")
+            return False
 
     @property
     def sum_uptime_readable(self) -> str | bool:
@@ -379,11 +387,12 @@ class XMRigAPI:
         Returns:
             str: Uptime in the format "days, hours:minutes:seconds", or False if not available.
         """
-        if self._summary_response and "uptime" in self._summary_response:
+        try:
             log.debug(str(timedelta(seconds=self._summary_response["uptime"])))
             return str(timedelta(seconds=self._summary_response["uptime"]))
-        log.error(f"An error occurred fetching the cached current uptime in a human-readable format data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached current uptime in a human-readable format data: {e}")
+            return False
 
     @property
     def sum_restricted(self) -> bool | None:
@@ -393,11 +402,12 @@ class XMRigAPI:
         Returns:
             bool: Current restricted status, or None if not available.
         """
-        if self._summary_response and "restricted" in self._summary_response:
+        try:
             log.debug(self._summary_response["restricted"])
             return self._summary_response["restricted"]
-        log.error(f"An error occurred fetching the cached restricted status data.")
-        return None
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached restricted status data: {e}")
+            return None
 
     @property
     def sum_resources(self) -> dict | bool:
@@ -407,11 +417,12 @@ class XMRigAPI:
         Returns:
             dict: Resources information, or False if not available.
         """
-        if self._summary_response and "resources" in self._summary_response:
+        try:
             log.debug(self._summary_response["resources"])
             return self._summary_response["resources"]
-        log.error(f"An error occurred fetching the cached resources data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached resources data: {e}")
+            return False
 
     @property
     def sum_memory_usage(self) -> dict | bool:
@@ -421,11 +432,12 @@ class XMRigAPI:
         Returns:
             dict: Memory usage information, or False if not available.
         """
-        if self._summary_response and "memory" in self._summary_response["resources"]:
+        try:
             log.debug(self._summary_response["resources"]["memory"])
             return self._summary_response["resources"]["memory"]
-        log.error(f"An error occurred fetching the cached memory usage data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached memory usage data: {e}")
+            return False
 
     @property
     def sum_free_memory(self) -> int | bool:
@@ -435,11 +447,12 @@ class XMRigAPI:
         Returns:
             int: Free memory information, or False if not available.
         """
-        if self._summary_response and "free" in self._summary_response["resources"]["memory"]:
+        try:
             log.debug(self._summary_response["resources"]["memory"]["free"])
             return self._summary_response["resources"]["memory"]["free"]
-        log.error(f"An error occurred fetching the cached free memory data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached free memory data: {e}")
+            return False
 
     @property
     def sum_total_memory(self) -> int | bool:
@@ -449,11 +462,12 @@ class XMRigAPI:
         Returns:
             int: Total memory information, or False if not available.
         """
-        if self._summary_response and "total" in self._summary_response["resources"]["memory"]:
+        try:
             log.debug(self._summary_response["resources"]["memory"]["total"])
             return self._summary_response["resources"]["memory"]["total"]
-        log.error(f"An error occurred fetching the cached total memory data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached total memory data: {e}")
+            return False
 
     @property
     def sum_resident_set_memory(self) -> int | bool:
@@ -463,11 +477,12 @@ class XMRigAPI:
         Returns:
             int: Resident set memory information, or False if not available.
         """
-        if self._summary_response and "resident_set" in self._summary_response["resources"]["memory"]:
+        try:
             log.debug(self._summary_response["resources"]["memory"]["resident_set_memory"])
             return self._summary_response["resources"]["memory"]["resident_set_memory"]
-        log.error(f"An error occurred fetching the cached resident set memory data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached resident set memory data: {e}")
+            return False
 
     @property
     def sum_load_average(self) -> list | bool:
@@ -477,11 +492,12 @@ class XMRigAPI:
         Returns:
             list: Load average information, or False if not available.
         """
-        if self._summary_response and "load_average" in self._summary_response["resources"]:
+        try:
             log.debug(self._summary_response["resources"]["load_average"])
             return self._summary_response["resources"]["load_average"]
-        log.error(f"An error occurred fetching the cached load average data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached load average data: {e}")
+            return False
 
     @property
     def sum_hardware_concurrency(self) -> int | bool:
@@ -491,11 +507,12 @@ class XMRigAPI:
         Returns:
             int: Hardware concurrency information, or False if not available.
         """
-        if self._summary_response and "hardware_concurrency" in self._summary_response["resources"]:
+        try:
             log.debug(self._summary_response["resources"]["hardware_concurrency"])
             return self._summary_response["resources"]["hardware_concurrency"]
-        log.error(f"An error occurred fetching the cached hardware concurrency data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached hardware concurrency data: {e}")
+            return False
 
     @property
     def sum_features(self) -> list | bool:
@@ -505,11 +522,12 @@ class XMRigAPI:
         Returns:
             list: Supported features information, or False if not available.
         """
-        if self._summary_response and "features" in self._summary_response["resources"]:
+        try:
             log.debug(self._summary_response["resources"]["features"])
             return self._summary_response["resources"]["features"]
-        log.error(f"An error occurred fetching the cached features data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached features data: {e}")
+            return False
 
     @property
     def sum_results(self) -> dict | bool:
@@ -519,11 +537,12 @@ class XMRigAPI:
         Returns:
             dict: Results information, or False if not available.
         """
-        if self._summary_response and "results" in self._summary_response:
+        try:
             log.debug(self._summary_response["results"])
             return self._summary_response["results"]
-        log.error(f"An error occurred fetching the cached results data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached results data: {e}")
+            return False
 
     @property
     def sum_current_difficulty(self) -> int | bool:
@@ -533,11 +552,12 @@ class XMRigAPI:
         Returns:
             int: Current difficulty, or False if not available.
         """
-        if self._summary_response and "results" in self._summary_response:
+        try:
             log.debug(self._summary_response["results"]["diff_current"])
             return self._summary_response["results"]["diff_current"]
-        log.error(f"An error occurred fetching the cached current difficulty data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached current difficulty data: {e}")
+            return False
 
     @property
     def sum_good_shares(self) -> int | bool:
@@ -547,11 +567,12 @@ class XMRigAPI:
         Returns:
             int: Good shares, or False if not available.
         """
-        if self._summary_response and "results" in self._summary_response:
+        try:
             log.debug(self._summary_response["results"]["shares_good"])
             return self._summary_response["results"]["shares_good"]
-        log.error(f"An error occurred fetching the cached good shares data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached good shares data: {e}")
+            return False
 
     @property
     def sum_total_shares(self) -> int | bool:
@@ -561,11 +582,12 @@ class XMRigAPI:
         Returns:
             int: Total shares, or False if not available.
         """
-        if self._summary_response and "results" in self._summary_response:
+        try:
             log.debug(self._summary_response["results"]["shares_total"])
             return self._summary_response["results"]["shares_total"]
-        log.error(f"An error occurred fetching the cached total shares data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached total shares data: {e}")
+            return False
 
     @property
     def sum_avg_time(self) -> int | bool:
@@ -575,11 +597,12 @@ class XMRigAPI:
         Returns:
             int: Average time information, or False if not available.
         """
-        if self._summary_response and "results" in self._summary_response:
+        try:
             log.debug(self._summary_response["results"]["avg_time"])
             return self._summary_response["results"]["avg_time"]
-        log.error(f"An error occurred fetching the cached average time data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached average time data: {e}")
+            return False
 
     @property
     def sum_avg_time_ms(self) -> int | bool:
@@ -589,11 +612,12 @@ class XMRigAPI:
         Returns:
             int: Average time in `ms` information, or False if not available.
         """
-        if self._summary_response and "results" in self._summary_response:
+        try:
             log.debug(self._summary_response["results"]["avg_time_ms"])
             return self._summary_response["results"]["avg_time_ms"]
-        log.error(f"An error occurred fetching the cached average time in `ms` data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached average time in `ms` data: {e}")
+            return False
 
     @property
     def sum_total_hashes(self) -> int | bool:
@@ -603,11 +627,12 @@ class XMRigAPI:
         Returns:
             int: Total number of hashes, or False if not available.
         """
-        if self._summary_response and "results" in self._summary_response:
+        try:
             log.debug(self._summary_response["results"]["hashes_total"])
             return self._summary_response["results"]["hashes_total"]
-        log.error(f"An error occurred fetching the cached total hashes data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached total hashes data: {e}")
+            return False
 
     @property
     def sum_best_results(self) -> list | bool:
@@ -617,11 +642,12 @@ class XMRigAPI:
         Returns:
             list: Best results, or False if not available.
         """
-        if self._summary_response and "results" in self._summary_response:
+        try:
             log.debug(self._summary_response["results"]["best"])
             return self._summary_response["results"]["best"]
-        log.error(f"An error occurred fetching the cached best results data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached best results data: {e}")
+            return False
 
     @property
     def sum_algorithm(self) -> str | bool:
@@ -631,11 +657,12 @@ class XMRigAPI:
         Returns:
             str: Current mining algorithm, or False if not available.
         """
-        if self._summary_response and "algo" in self._summary_response:
+        try:
             log.debug(self._summary_response["algo"])
             return self._summary_response["algo"]
-        log.error(f"An error occurred fetching the cached current mining alogorithm data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached current mining alogorithm data: {e}")
+            return False
 
     @property
     def sum_connection(self) -> dict | bool:
@@ -645,11 +672,12 @@ class XMRigAPI:
         Returns:
             dict: Connection information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"])
             return self._summary_response["connection"]
-        log.error(f"An error occurred fetching the cached connection data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached connection data: {e}")
+            return False
 
     @property
     def sum_pool_info(self) -> str | bool:
@@ -659,11 +687,12 @@ class XMRigAPI:
         Returns:
             str: Pool information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["pool"])
             return self._summary_response["connection"]["pool"]
-        log.error(f"An error occurred fetching the cached pool information data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool information data: {e}")
+            return False
 
     @property
     def sum_pool_ip_address(self) -> str | bool:
@@ -673,11 +702,12 @@ class XMRigAPI:
         Returns:
             str: IP address, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["ip"])
             return self._summary_response["connection"]["ip"]
-        log.error(f"An error occurred fetching the cached IP address data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached IP address data: {e}")
+            return False
 
     @property
     def sum_pool_uptime(self) -> int | bool:
@@ -687,11 +717,12 @@ class XMRigAPI:
         Returns:
             int: Pool uptime information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["uptime"])
             return self._summary_response["connection"]["uptime"]
-        log.error(f"An error occurred fetching the cached pool uptime data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool uptime data: {e}")
+            return False
 
     @property
     def sum_pool_uptime_ms(self) -> int | bool:
@@ -701,11 +732,12 @@ class XMRigAPI:
         Returns:
             int: Pool uptime in ms, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["uptime_ms"])
             return self._summary_response["connection"]["uptime_ms"]
-        log.error(f"An error occurred fetching the cached pool uptime in `ms` data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool uptime in `ms` data: {e}")
+            return False
 
     @property
     def sum_pool_ping(self) -> int | bool:
@@ -715,11 +747,12 @@ class XMRigAPI:
         Returns:
             int: Pool ping information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["ping"])
             return self._summary_response["connection"]["ping"]
-        log.error(f"An error occurred fetching the cached pool ping data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool ping data: {e}")
+            return False
 
     @property
     def sum_pool_failures(self) -> int | bool:
@@ -729,11 +762,12 @@ class XMRigAPI:
         Returns:
             int: Pool failures information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["failures"])
             return self._summary_response["connection"]["failures"]
-        log.error(f"An error occurred fetching the cached pool failures data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool failures data: {e}")
+            return False
 
     @property
     def sum_pool_tls(self) -> bool | None:
@@ -743,11 +777,12 @@ class XMRigAPI:
         Returns:
             bool: Pool tls status, or None if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["tls"])
             return self._summary_response["connection"]["tls"]
-        log.error(f"An error occurred fetching the cached pool tls data.")
-        return None
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool tls data: {e}")
+            return None
 
     @property
     def sum_pool_tls_fingerprint(self) -> str | bool:
@@ -757,11 +792,12 @@ class XMRigAPI:
         Returns:
             str: Pool tls fingerprint information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["tls-fingerprint"])
             return self._summary_response["connection"]["tls-fingerprint"]
-        log.error(f"An error occurred fetching the cached pool tls fingerprint data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool tls fingerprint data: {e}")
+            return False
 
     @property
     def sum_pool_algo(self) -> str | bool:
@@ -771,11 +807,12 @@ class XMRigAPI:
         Returns:
             str: Pool algorithm information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["algo"])
             return self._summary_response["connection"]["algo"]
-        log.error(f"An error occurred fetching the cached pool algorithm data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool algorithm data: {e}")
+            return False
 
     @property
     def sum_pool_diff(self) -> int | bool:
@@ -785,11 +822,12 @@ class XMRigAPI:
         Returns:
             int: Pool difficulty information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["diff"])
             return self._summary_response["connection"]["diff"]
-        log.error(f"An error occurred fetching the cached pool difficulty data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool difficulty data: {e}")
+            return False
 
     @property
     def sum_pool_accepted_jobs(self) -> int | bool:
@@ -799,11 +837,12 @@ class XMRigAPI:
         Returns:
             int: Number of accepted jobs, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["accepted"])
             return self._summary_response["connection"]["accepted"]
-        log.error(f"An error occurred fetching the cached pool accepted jobs data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool accepted jobs data: {e}")
+            return False
 
     @property
     def sum_pool_rejected_jobs(self) -> int | bool:
@@ -813,11 +852,12 @@ class XMRigAPI:
         Returns:
             int: Number of rejected jobs, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["rejected"])
             return self._summary_response["connection"]["rejected"]
-        log.error(f"An error occurred fetching the cached pool rejected jobs data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool rejected jobs data: {e}")
+            return False
 
     @property
     def sum_pool_average_time(self) -> int | bool:
@@ -827,25 +867,27 @@ class XMRigAPI:
         Returns:
             int: Pool average time information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["avg_time"])
             return self._summary_response["connection"]["avg_time"]
-        log.error(f"An error occurred fetching the cached pool average time data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool average time data: {e}")
+            return False
 
     @property
     def sum_pool_average_time_ms(self) -> int | bool:
         """
-        Retrieves the cached pool average in ms from the summary data.
+        Retrieves the cached pool average time in ms from the summary data.
 
         Returns:
-            int: Pool average in ms, or False if not available.
+            int: Pool average time in ms, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["avg_time_ms"])
             return self._summary_response["connection"]["avg_time_ms"]
-        log.error(f"An error occurred fetching the cached pool average time in `ms` data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool average time in `ms` data: {e}")
+            return False
 
     @property
     def sum_pool_total_hashes(self) -> int | bool:
@@ -855,11 +897,12 @@ class XMRigAPI:
         Returns:
             int: Pool total hashes information, or False if not available.
         """
-        if self._summary_response and "connection" in self._summary_response:
+        try:
             log.debug(self._summary_response["connection"]["hashes_total"])
             return self._summary_response["connection"]["hashes_total"]
-        log.error(f"An error occurred fetching the cached pool total hashes data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached pool total hashes data: {e}")
+            return False
 
     @property
     def sum_version(self) -> str | bool:
@@ -869,11 +912,12 @@ class XMRigAPI:
         Returns:
             str: Version information, or False if not available.
         """
-        if self._summary_response and "version" in self._summary_response:
+        try:
             log.debug(self._summary_response["version"])
             return self._summary_response["version"]
-        log.error(f"An error occurred fetching the cached version data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached version data: {e}")
+            return False
 
     @property
     def sum_kind(self) -> str | bool:
@@ -883,11 +927,12 @@ class XMRigAPI:
         Returns:
             str: Kind information, or False if not available.
         """
-        if self._summary_response and "kind" in self._summary_response:
+        try:
             log.debug(self._summary_response["kind"])
             return self._summary_response["kind"]
-        log.error(f"An error occurred fetching the cached kind data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached kind data: {e}")
+            return False
 
     @property
     def sum_ua(self) -> str | bool:
@@ -897,11 +942,12 @@ class XMRigAPI:
         Returns:
             str: User agent information, or False if not available.
         """
-        if self._summary_response and "ua" in self._summary_response:
+        try:
             log.debug(self._summary_response["ua"])
             return self._summary_response["ua"]
-        log.error(f"An error occurred fetching the cached user agent data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached user agent data: {e}")
+            return False
 
     @property
     def sum_cpu_info(self) -> dict | bool:
@@ -911,11 +957,12 @@ class XMRigAPI:
         Returns:
             dict: CPU information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"])
             return self._summary_response["cpu"]
-        log.error(f"An error occurred fetching the cached CPU data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU data: {e}")
+            return False
 
     @property
     def sum_cpu_brand(self) -> str | bool:
@@ -925,11 +972,12 @@ class XMRigAPI:
         Returns:
             str: CPU brand information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["brand"])
             return self._summary_response["cpu"]["brand"]
-        log.error(f"An error occurred fetching the cached CPU brand data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU brand data: {e}")
+            return False
 
     @property
     def sum_cpu_family(self) -> int | bool:
@@ -939,11 +987,12 @@ class XMRigAPI:
         Returns:
             int: CPU family information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["family"])
             return self._summary_response["cpu"]["family"]
-        log.error(f"An error occurred fetching the cached CPU family data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU family data: {e}")
+            return False
 
     @property
     def sum_cpu_model(self) -> int | bool:
@@ -953,11 +1002,12 @@ class XMRigAPI:
         Returns:
             int: CPU model information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["model"])
             return self._summary_response["cpu"]["model"]
-        log.error(f"An error occurred fetching the cached CPU model data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU model data: {e}")
+            return False
 
     @property
     def sum_cpu_stepping(self) -> int | bool:
@@ -967,11 +1017,12 @@ class XMRigAPI:
         Returns:
             int: CPU stepping information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["stepping"])
             return self._summary_response["cpu"]["stepping"]
-        log.error(f"An error occurred fetching the cached CPU stepping data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU stepping data: {e}")
+            return False
 
     @property
     def sum_cpu_proc_info(self) -> int | bool:
@@ -981,67 +1032,72 @@ class XMRigAPI:
         Returns:
             int: CPU frequency information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["proc_info"])
             return self._summary_response["cpu"]["proc_info"]
-        log.error(f"An error occurred fetching the cached CPU frequency data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU frequency data: {e}")
+            return False
 
     @property
-    def sum_cpu_aes(self) -> int | bool:
+    def sum_cpu_aes(self) -> bool | None:
         """
         Retrieves the cached CPU aes information from the summary data.
 
         Returns:
-            int: CPU aes information, or False if not available.
+            bool: CPU aes information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["aes"])
             return self._summary_response["cpu"]["aes"]
-        log.error(f"An error occurred fetching the cached CPU aes data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU aes data: {e}")
+            return None
 
     @property
-    def sum_cpu_avx2(self) -> int | bool:
+    def sum_cpu_avx2(self) -> bool | None:
         """
         Retrieves the cached CPU avx2 information from the summary data.
 
         Returns:
-            int: CPU avx2 information, or False if not available.
+            bool: CPU avx2 information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["avx2"])
             return self._summary_response["cpu"]["avx2"]
-        log.error(f"An error occurred fetching the cached CPU avx2 data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU avx2 data: {e}")
+            return None
 
     @property
-    def sum_cpu_x64(self) -> int | bool:
+    def sum_cpu_x64(self) -> bool | None:
         """
         Retrieves the cached CPU x64 information from the summary data.
 
         Returns:
-            int: CPU x64 information, or False if not available.
+            bool: CPU x64 information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["x64"])
             return self._summary_response["cpu"]["x64"]
-        log.error(f"An error occurred fetching the cached CPU x64 data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU x64 data: {e}")
+            return None
 
     @property
-    def sum_cpu_64_bit(self) -> int | bool:
+    def sum_cpu_64_bit(self) -> bool | None:
         """
         Retrieves the cached CPU 64-bit information from the summary data.
 
         Returns:
-            int: CPU 64-bit information, or False if not available.
+            bool: CPU 64-bit information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["64_bit"])
             return self._summary_response["cpu"]["64_bit"]
-        log.error(f"An error occurred fetching the cached CPU x64-bit data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU x64-bit data: {e}")
+            return None
 
     @property
     def sum_cpu_l2(self) -> int | bool:
@@ -1051,11 +1107,12 @@ class XMRigAPI:
         Returns:
             int: CPU l2 cache information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["l2"])
             return self._summary_response["cpu"]["l2"]
-        log.error(f"An error occurred fetching the cached CPU l2 cache data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU l2 cache data: {e}")
+            return False
 
     @property
     def sum_cpu_l3(self) -> int | bool:
@@ -1065,11 +1122,12 @@ class XMRigAPI:
         Returns:
             int: CPU l3 cache information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["l3"])
             return self._summary_response["cpu"]["l3"]
-        log.error(f"An error occurred fetching the cached CPU l3 cache data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU l3 cache data: {e}")
+            return False
 
     @property
     def sum_cpu_cores(self) -> int | bool:
@@ -1079,11 +1137,12 @@ class XMRigAPI:
         Returns:
             int: CPU cores information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["cores"])
             return self._summary_response["cpu"]["cores"]
-        log.error(f"An error occurred fetching the cached CPU cores data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU cores data: {e}")
+            return False
 
     @property
     def sum_cpu_threads(self) -> int | bool:
@@ -1093,11 +1152,12 @@ class XMRigAPI:
         Returns:
             int: CPU threads information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["threads"])
             return self._summary_response["cpu"]["threads"]
-        log.error(f"An error occurred fetching the cached CPU threads data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU threads data: {e}")
+            return False
 
     @property
     def sum_cpu_packages(self) -> int | bool:
@@ -1107,11 +1167,12 @@ class XMRigAPI:
         Returns:
             int: CPU packages information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["packages"])
             return self._summary_response["cpu"]["packages"]
-        log.error(f"An error occurred fetching the cached CPU packages data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU packages data: {e}")
+            return False
 
     @property
     def sum_cpu_nodes(self) -> int | bool:
@@ -1121,11 +1182,12 @@ class XMRigAPI:
         Returns:
             int: CPU nodes information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["nodes"])
             return self._summary_response["cpu"]["nodes"]
-        log.error(f"An error occurred fetching the cached CPU nodes data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU nodes data: {e}")
+            return False
 
     @property
     def sum_cpu_backend(self) -> str | bool:
@@ -1135,11 +1197,12 @@ class XMRigAPI:
         Returns:
             str: CPU backend information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["backend"])
             return self._summary_response["cpu"]["backend"]
-        log.error(f"An error occurred fetching the cached CPU backend data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU backend data: {e}")
+            return False
 
     @property
     def sum_cpu_msr(self) -> str | bool:
@@ -1149,11 +1212,12 @@ class XMRigAPI:
         Returns:
             str: CPU msr information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["msr"])
             return self._summary_response["cpu"]["msr"]
-        log.error(f"An error occurred fetching the cached CPU msr data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU msr data: {e}")
+            return False
 
     @property
     def sum_cpu_assembly(self) -> str | bool:
@@ -1163,11 +1227,12 @@ class XMRigAPI:
         Returns:
             str: CPU assembly information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["assembly"])
             return self._summary_response["cpu"]["assembly"]
-        log.error(f"An error occurred fetching the cached CPU assembly data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU assembly data: {e}")
+            return False
 
     @property
     def sum_cpu_arch(self) -> str | bool:
@@ -1177,11 +1242,12 @@ class XMRigAPI:
         Returns:
             str: CPU architecture information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["arch"])
             return self._summary_response["cpu"]["arch"]
-        log.error(f"An error occurred fetching the cached CPU architecture data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU architecture data: {e}")
+            return False
 
     @property
     def sum_cpu_flags(self) -> list | bool:
@@ -1191,11 +1257,12 @@ class XMRigAPI:
         Returns:
             list: CPU flags information, or False if not available.
         """
-        if self._summary_response and "cpu" in self._summary_response:
+        try:
             log.debug(self._summary_response["cpu"]["flags"])
             return self._summary_response["cpu"]["flags"]
-        log.error(f"An error occurred fetching the cached CPU flags data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU flags data: {e}")
+            return False
 
     @property
     def sum_donate_level(self) -> int | bool:
@@ -1205,25 +1272,27 @@ class XMRigAPI:
         Returns:
             int: Donation level information, or False if not available.
         """
-        if self._summary_response and "donate_level" in self._summary_response:
+        try:
             log.debug(self._summary_response["donate_level"])
             return self._summary_response["donate_level"]
-        log.error(f"An error occurred fetching the cached donation level data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached donation level data: {e}")
+            return False
 
     @property
-    def sum_paused(self) -> int | bool:
+    def sum_paused(self) -> bool | None:
         """
         Retrieves the cached paused status of the miner from the summary data.
 
         Returns:
-            int: True if the miner is paused, False otherwise, or False if not available.
+            bool: True if the miner is paused, False otherwise, or None if not available.
         """
-        if self._summary_response and "paused" in self._summary_response:
+        try:
             log.debug(self._summary_response["paused"])
             return self._summary_response["paused"]
-        log.error(f"An error occurred fetching the cached paused status data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached paused status data: {e}")
+            return None
 
     @property
     def sum_algorithms(self) -> list | bool:
@@ -1233,11 +1302,12 @@ class XMRigAPI:
         Returns:
             list: Algorithms information, or False if not available.
         """
-        if self._summary_response and "algorithms" in self._summary_response:
+        try:
             log.debug(self._summary_response["algorithms"])
             return self._summary_response["algorithms"]
-        log.error(f"An error occurred fetching the cached algorithms data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached algorithms data: {e}")
+            return False
 
     @property
     def sum_hashrates(self) -> dict | bool:
@@ -1247,11 +1317,12 @@ class XMRigAPI:
         Returns:
             dict: Current hashrates, or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._summary_response["hashrate"])
             return self._summary_response["hashrate"]
-        log.error(f"An error occurred fetching the cached current hashrates data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached current hashrates data: {e}")
+            return False
 
     @property
     def sum_hashrate_10s(self) -> int | bool:
@@ -1261,11 +1332,12 @@ class XMRigAPI:
         Returns:
             int: Current hashrate (10s), or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._summary_response["hashrate"]["total"][0])
             return self._summary_response["hashrate"]["total"][0]
-        log.error(f"An error occurred fetching the cached current hashrate (10s) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached current hashrate (10s) data: {e}")
+            return False
 
     @property
     def sum_hashrate_1m(self) -> int | bool:
@@ -1275,11 +1347,12 @@ class XMRigAPI:
         Returns:
             int: Current hashrate (1m), or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._summary_response["hashrate"]["total"][1])
             return self._summary_response["hashrate"]["total"][1]
-        log.error(f"An error occurred fetching the cached current hashrate (1m) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached current hashrate (1m) data: {e}")
+            return False
 
     @property
     def sum_hashrate_15m(self) -> int | bool:
@@ -1289,11 +1362,12 @@ class XMRigAPI:
         Returns:
             int: Current hashrate (15m), or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._summary_response["hashrate"]["total"][2])
             return self._summary_response["hashrate"]["total"][2]
-        log.error(f"An error occurred fetching the cached current hashrate (15m) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached current hashrate (15m) data: {e}")
+            return False
 
     @property
     def sum_hashrate_highest(self) -> int | bool:
@@ -1303,11 +1377,12 @@ class XMRigAPI:
         Returns:
             int: Current hashrate (highest), or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._summary_response["hashrate"]["highest"])
             return self._summary_response["hashrate"]["highest"]
-        log.error(f"An error occurred fetching the cached highest hashrate data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached highest hashrate data: {e}")
+            return False
 
     @property
     def sum_hugepages(self) -> list | bool:
@@ -1317,13 +1392,15 @@ class XMRigAPI:
         Returns:
             list: Current hugepages, or False if not available.
         """
-        if self._summary_response and "hugepages" in self._summary_response:
+        try:
             log.debug(self._summary_response["hugepages"])
             return self._summary_response["hugepages"]
-        log.error(f"An error occurred fetching the cached hugepages data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached hugepages data: {e}")
+            return False
 
-    # * Data Provided by the backends endpoint
+    # ***** Data Provided by the backends endpoint
+
     @property
     def enabled_backends(self) -> list | bool:
         """
@@ -1333,12 +1410,16 @@ class XMRigAPI:
             list: List of enabled backends, or False if not available.
         """
         backend_types = []
-        if self._backends_response:
+        try:
             for i in self._backends_response:
                 if "type" in i and i["enabled"] == True:
                     backend_types.append(i["type"])
             log.debug(backend_types)
             return backend_types
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached enabled backends data: {e}")
+            return False
+    
     @property
     def be_cpu_type(self) -> str | bool:
         """
@@ -1362,11 +1443,12 @@ class XMRigAPI:
         Returns:
             bool: Bool representing enabled status, or None if not available.
         """
-        if self._backends_response and "enabled" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["enabled"])
             return self._backends_response[0]["enabled"]
-        log.error(f"An error occurred fetching the cached CPU enabled status data.")
-        return None
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU enabled status data: {e}")
+            return None
 
     @property
     def be_cpu_algo(self) -> str | bool:
@@ -1374,13 +1456,14 @@ class XMRigAPI:
         Retrieves the cached CPU algorithm information from the backends data.
 
         Returns:
-            str: Bool representing algorithm information, or False if not available.
+            str: Algorithm information, or False if not available.
         """
-        if self._backends_response and "algo" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["algo"])
             return self._backends_response[0]["algo"]
-        log.error(f"An error occurred fetching the cached CPU algorithm data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU algorithm data: {e}")
+            return False
 
     @property
     def be_cpu_profile(self) -> str | bool:
@@ -1388,13 +1471,14 @@ class XMRigAPI:
         Retrieves the cached CPU profile information from the backends data.
 
         Returns:
-            str: Bool representing profile information, or False if not available.
+            str: Profile information, or False if not available.
         """
-        if self._backends_response and "profile" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["profile"])
             return self._backends_response[0]["profile"]
-        log.error(f"An error occurred fetching the cached CPU profile data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU profile data: {e}")
+            return False
 
     @property
     def be_cpu_hw_aes(self) -> bool | None:
@@ -1404,11 +1488,12 @@ class XMRigAPI:
         Returns:
             bool: Bool representing hw-aes support status, or None if not available.
         """
-        if self._backends_response and "hw-aes" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["hw-aes"])
             return self._backends_response[0]["hw-aes"]
-        log.error(f"An error occurred fetching the cached CPU hw-aes support data.")
-        return None
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU hw-aes support data: {e}")
+            return None
 
     @property
     def be_cpu_priority(self) -> int | bool:
@@ -1419,13 +1504,14 @@ class XMRigAPI:
         value `-1` means XMRig doesn't change threads priority at all,
 
         Returns:
-            int: Int representing mining thread priority, or False if not available.
+            int: Mining thread priority, or False if not available.
         """
-        if self._backends_response and "priority" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["priority"])
             return self._backends_response[0]["priority"]
-        log.error(f"An error occurred fetching the cached CPU priority data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU priority data: {e}")
+            return False
 
     @property
     def be_cpu_msr(self) -> bool | None:
@@ -1435,11 +1521,12 @@ class XMRigAPI:
         Returns:
             bool: Bool representing msr information, or None if not available.
         """
-        if self._backends_response and "msr" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["msr"])
             return self._backends_response[0]["msr"]
-        log.error(f"An error occurred fetching the cached CPU msr data.")
-        return None
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU msr data: {e}")
+            return None
 
     @property
     def be_cpu_asm(self) -> str | bool:
@@ -1447,13 +1534,14 @@ class XMRigAPI:
         Retrieves the cached CPU asm information from the backends data.
 
         Returns:
-            str: Bool representing asm information, or False if not available.
+            str: ASM information, or False if not available.
         """
-        if self._backends_response and "asm" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["asm"])
             return self._backends_response[0]["asm"]
-        log.error(f"An error occurred fetching the cached CPU asm data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU asm data: {e}")
+            return False
 
     @property
     def be_cpu_argon2_impl(self) -> str | bool:
@@ -1461,13 +1549,14 @@ class XMRigAPI:
         Retrieves the cached CPU argon2 implementation information from the backends data.
 
         Returns:
-            str: Bool representing argon2 implementation information, or False if not available.
+            str: Argon2 implementation information, or False if not available.
         """
-        if self._backends_response and "argon2-impl" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["argon2-impl"])
             return self._backends_response[0]["argon2-impl"]
-        log.error(f"An error occurred fetching the cached CPU argon2 implementation data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU argon2 implementation data: {e}")
+            return False
 
     @property
     def be_cpu_hugepages(self) -> list | bool:
@@ -1475,13 +1564,14 @@ class XMRigAPI:
         Retrieves the cached CPU hugepages information from the backends data.
 
         Returns:
-            list: Bool representing hugepages information, or False if not available.
+            list: Hugepages information, or False if not available.
         """
-        if self._backends_response and "hugepages" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["hugepages"])
             return self._backends_response[0]["hugepages"]
-        log.error(f"An error occurred fetching the cached CPU hugepages data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU hugepages data: {e}")
+            return False
 
     @property
     def be_cpu_memory(self) -> int | bool:
@@ -1489,11 +1579,15 @@ class XMRigAPI:
         Retrieves the cached CPU memory information from the backends data.
 
         Returns:
-            int: Bool representing memory information, or False if not available.
+            int: Memory information, or False if not available.
         """
-        if self._backends_response and "memory" in self._backends_response[0]:
+        try:
             log.debug(self._backends_response[0]["memory"])
             return self._backends_response[0]["memory"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU memory data: {e}")
+            return False
+    
     @property
     def be_cpu_hashrates(self) -> int | bool:
         """
@@ -1700,11 +1794,12 @@ class XMRigAPI:
         Returns:
             bool: Bool representing enabled information, or None if not available.
         """
-        if self._backends_response and "enabled" in self._backends_response[1]:
+        try:
             log.debug(self._backends_response[1]["enabled"])
             return self._backends_response[1]["enabled"]
-        log.error(f"An error occurred fetching the cached OpenCL enabled data.")
-        return None
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL enabled data: {e}")
+            return None
 
     @property
     def be_opencl_algo(self) -> str | bool:
@@ -1712,13 +1807,14 @@ class XMRigAPI:
         Retrieves the cached OpenCL algorithm information from the backends data.
 
         Returns:
-            str: Bool representing algorithm information, or False if not available.
+            str: Algorithm information, or False if not available.
         """
-        if self._backends_response and "algo" in self._backends_response[1]:
+        try:
             log.debug(self._backends_response[1]["algo"])
             return self._backends_response[1]["algo"]
-        log.error(f"An error occurred fetching the cached OpenCL algorithm data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL algorithm data: {e}")
+            return False
 
     @property
     def be_opencl_profile(self) -> str | bool:
@@ -1726,25 +1822,30 @@ class XMRigAPI:
         Retrieves the cached OpenCL profile information from the backends data.
 
         Returns:
-            str: Bool representing profile information, or False if not available.
+            str: Profile information, or False if not available.
         """
-        if self._backends_response and "profile" in self._backends_response[1]:
+        try:
             log.debug(self._backends_response[1]["profile"])
             return self._backends_response[1]["profile"]
-        log.error(f"An error occurred fetching the cached OpenCL profile data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL profile data: {e}")
+            return False
 
     @property
-    def be_opencl_platform(self) -> str | bool:
+    def be_opencl_platform(self) -> dict | bool:
         """
         Retrieves the cached OpenCL platform information from the backends data.
 
         Returns:
-            str: Bool representing platform information, or False if not available.
+            dict: Platform information, or False if not available.
         """
-        if self._backends_response and "platform" in self._backends_response[1]:
+        try:
             log.debug(self._backends_response[1]["platform"])
             return self._backends_response[1]["platform"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL platform data: {e}")
+            return False
+    
     @property
     def be_opencl_platform_index(self) -> int | bool:
         """
@@ -2231,13 +2332,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current type info from the backends data.
 
         Returns:
-            str: Current type info, or False if not available.
+            str: Type info, or False if not available.
         """
-        if self._backends_response and "type" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["type"])
             return self._backends_response[2]["type"]
-        log.error(f"An error occurred fetching the cached Cuda type data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda type data: {e}")
+            return False
 
     @property
     def be_cuda_enabled(self) -> bool | None:
@@ -2245,13 +2347,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current enabled info from the backends data.
 
         Returns:
-            bool: Current enabled info, or None if not available.
+            bool: Current enabled status, or None if not available.
         """
-        if self._backends_response and "enabled" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["enabled"])
             return self._backends_response[2]["enabled"]
-        log.error(f"An error occurred fetching the cached Cuda enabled status data.")
-        return None
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda enabled status data: {e}")
+            return None
 
     @property
     def be_cuda_algo(self) -> str | bool:
@@ -2259,13 +2362,14 @@ class XMRigAPI:
         Retrieves the cached Cuda algorithm information from the backends data.
 
         Returns:
-            str: Bool representing algorithm information, or False if not available.
+            str: Algorithm information, or False if not available.
         """
-        if self._backends_response and "algo" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["algo"])
             return self._backends_response[2]["algo"]
-        log.error(f"An error occurred fetching the cached Cuda algorithm data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda algorithm data: {e}")
+            return False
 
     @property
     def be_cuda_profile(self) -> str | bool:
@@ -2273,13 +2377,14 @@ class XMRigAPI:
         Retrieves the cached Cuda profile information from the backends data.
 
         Returns:
-            str: Bool representing profile information, or False if not available.
+            str: Profile information, or False if not available.
         """
-        if self._backends_response and "profile" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["profile"])
             return self._backends_response[2]["profile"]
-        log.error(f"An error occurred fetching the cached Cuda profile data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda profile data: {e}")
+            return False
 
     @property
     def be_cuda_versions(self) -> dict | bool:
@@ -2287,13 +2392,14 @@ class XMRigAPI:
         Retrieves the cached Cuda versions information from the backends data.
 
         Returns:
-            dict: Bool representing versions information, or False if not available.
+            dict: Cuda versions information, or False if not available.
         """
-        if self._backends_response and "versions" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["versions"])
             return self._backends_response[2]["versions"]
-        log.error(f"An error occurred fetching the cached Cuda versions data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda versions data: {e}")
+            return False
 
     @property
     def be_cuda_runtime(self) -> str | bool:
@@ -2301,13 +2407,14 @@ class XMRigAPI:
         Retrieves the cached Cuda runtime information from the backends data.
 
         Returns:
-           str: Bool representing cuda runtime information, or False if not available.
+           str: Cuda runtime information, or False if not available.
         """
-        if self._backends_response and "cuda-runtime" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["versions"]["cuda-runtime"])
             return self._backends_response[2]["versions"]["cuda-runtime"]
-        log.error(f"An error occurred fetching the cached Cuda runtime data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda runtime data: {e}")
+            return False
 
     @property
     def be_cuda_driver(self) -> str | bool:
@@ -2315,13 +2422,14 @@ class XMRigAPI:
         Retrieves the cached Cuda driver information from the backends data.
 
         Returns:
-            str: Bool representing cuda driver information, or False if not available.
+            str: Cuda driver information, or False if not available.
         """
-        if self._backends_response and "cuda-driver" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["versions"]["cuda-driver"])
             return self._backends_response[2]["versions"]["cuda-driver"]
-        log.error(f"An error occurred fetching the cached Cuda driver data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda driver data: {e}")
+            return False
 
     @property
     def be_cuda_plugin(self) -> str | bool:
@@ -2329,27 +2437,29 @@ class XMRigAPI:
         Retrieves the cached Cuda plugin information from the backends data.
 
         Returns:
-            str: Bool representing cuda plugin information, or False if not available.
+            str: Cuda plugin information, or False if not available.
         """
-        if self._backends_response and "plugin" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["versions"]["plugin"])
             return self._backends_response[2]["versions"]["plugin"]
-        log.error(f"An error occurred fetching the cached Cuda plugin data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda plugin data: {e}")
+            return False
 
     @property
-    def be_cuda_hashrate(self) -> list | bool:
+    def be_cuda_hashrates(self) -> list | bool:
         """
-        Retrieves the cached Cuda current hashrate info from the backends data.
+        Retrieves the cached Cuda current hashrates info from the backends data.
 
         Returns:
-            list: Current hashrate info, or False if not available.
+            list: Hashrates info, or False if not available.
         """
-        if self._backends_response and "hashrate" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["hashrate"])
             return self._backends_response[2]["hashrate"]
-        log.error(f"An error occurred fetching the cached Cuda current hashrate data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda current hashrates data: {e}")
+            return False
 
     @property
     def be_cuda_hashrate_10s(self) -> int | bool:
@@ -2357,13 +2467,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current hashrate (10s) info from the backends data.
 
         Returns:
-           int: Current hashrate (10s) info, or False if not available.
+           int: Hashrate (10s) info, or False if not available.
         """
-        if self._backends_response and "hashrate" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["hashrate"][0])
             return self._backends_response[2]["hashrate"][0]
-        log.error(f"An error occurred fetching the cached Cuda current hashrate (10s) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda current hashrate (10s) data: {e}")
+            return False
 
     @property
     def be_cuda_hashrate_1m(self) -> int | bool:
@@ -2371,13 +2482,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current hashrate (1m) info from the backends data.
 
         Returns:
-            int: Current hashrate (1m) info, or False if not available.
+            int: Hashrate (1m) info, or False if not available.
         """
-        if self._backends_response and "hashrate" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["hashrate"][1])
             return self._backends_response[2]["hashrate"][1]
-        log.error(f"An error occurred fetching the cached Cuda current hashrate (1m) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda current hashrate (1m) data: {e}")
+            return False
 
     @property
     def be_cuda_hashrate_15m(self) -> int | bool:
@@ -2385,13 +2497,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current hashrate (15m) info from the backends data.
 
         Returns:
-            int: Current hashrate (15m) info, or False if not available.
+            int: Hashrate (15m) info, or False if not available.
         """
-        if self._backends_response and "hashrate" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["hashrate"][2])
             return self._backends_response[2]["hashrate"][2]
-        log.error(f"An error occurred fetching the cached Cuda current hashrate (15m) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda current hashrate (15m) data: {e}")
+            return False
 
     @property
     def be_cuda_threads(self) -> dict | bool:
@@ -2399,13 +2512,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads info from the backends data.
 
         Returns:
-            dict: Current threads info, or False if not available.
+            dict: Threads info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0])
             return self._backends_response[2]["threads"][0]
-        log.error(f"An error occurred fetching the cached Cuda threads data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads data: {e}")
+            return False
 
     @property
     def be_cuda_threads_index(self) -> int | bool:
@@ -2413,13 +2527,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads index info from the backends data.
 
         Returns:
-            int: Current threads index info, or False if not available.
+            int: Threads index info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["index"])
             return self._backends_response[2]["threads"][0]["index"]
-        log.error(f"An error occurred fetching the cached Cuda threads index data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads index data: {e}")
+            return False
 
     @property
     def be_cuda_threads_amount(self) -> int | bool:
@@ -2427,13 +2542,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads amount info from the backends data.
 
         Returns:
-            int: Current threads amount info, or False if not available.
+            int: Threads amount info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["threads"])
             return self._backends_response[2]["threads"][0]["threads"]
-        log.error(f"An error occurred fetching the cached Cuda threads amount data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads amount data: {e}")
+            return False
 
     @property
     def be_cuda_threads_blocks(self) -> int | bool:
@@ -2441,13 +2557,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads blocks info from the backends data.
 
         Returns:
-            int: Current threads blocks info, or False if not available.
+            int: Threads blocks info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["blocks"])
             return self._backends_response[2]["threads"][0]["blocks"]
-        log.error(f"An error occurred fetching the cached Cuda threads blocks data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads blocks data: {e}")
+            return False
 
     @property
     def be_cuda_threads_bfactor(self) -> int | bool:
@@ -2455,13 +2572,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads bfactor info from the backends data.
 
         Returns:
-            int: Current threads bfactor info, or False if not available.
+            int: Threads bfactor info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["bfactor"])
             return self._backends_response[2]["threads"][0]["bfactor"]
-        log.error(f"An error occurred fetching the cached Cuda threads bfactor data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads bfactor data: {e}")
+            return False
 
     @property
     def be_cuda_threads_bsleep(self) -> int | bool:
@@ -2469,13 +2587,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads bsleep info from the backends data.
 
         Returns:
-            int: Current threads bsleep info, or False if not available.
+            int: Threads bsleep info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["bsleep"])
             return self._backends_response[2]["threads"][0]["bsleep"]
-        log.error(f"An error occurred fetching the cached Cuda threads bsleep data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads bsleep data: {e}")
+            return False
 
     @property
     def be_cuda_threads_affinity(self) -> int | bool:
@@ -2483,13 +2602,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads affinity info from the backends data.
 
         Returns:
-            int: Current threads affinity info, or False if not available.
+            int: Threads affinity info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["affinity"])
             return self._backends_response[2]["threads"][0]["affinity"]
-        log.error(f"An error occurred fetching the cached Cuda threads affinity data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads affinity data: {e}")
+            return False
 
     @property
     def be_cuda_threads_dataset_host(self) -> bool | None:
@@ -2497,13 +2617,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads dataset host info from the backends data.
 
         Returns:
-            bool: Current threads dataset host info, or None if not available.
+            bool: Threads dataset host info, or None if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["dataset_host"])
             return self._backends_response[2]["threads"][0]["dataset_host"]
-        log.error(f"An error occurred fetching the cached Cuda threads dataset host data.")
-        return None
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads dataset host data: {e}")
+            return None
 
     @property
     def be_cuda_threads_hashrates(self) -> list | bool:
@@ -2511,13 +2632,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current hashrates (10s/1m/15m) from the summary data.
 
         Returns:
-            list: Current hashrates, or False if not available.
+            list: Hashrates, or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["hashrate"])
             return self._backends_response[2]["threads"][0]["hashrate"]
-        log.error(f"An error occurred fetching the cached Cuda threads hashrates data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads hashrates data: {e}")
+            return False
 
     @property
     def be_cuda_threads_hashrate_10s(self) -> int | bool:
@@ -2525,13 +2647,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current hashrate (10s) from the summary data.
 
         Returns:
-            int: Current hashrate (10s), or False if not available.
+            int: Hashrate (10s), or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["hashrate"][0])
             return self._backends_response[2]["threads"][0]["hashrate"][0]
-        log.error(f"An error occurred fetching the cached Cuda threads hashrate (10s) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads hashrate (10s) data: {e}")
+            return False
 
     @property
     def be_cuda_threads_hashrate_1m(self) -> int | bool:
@@ -2539,13 +2662,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current hashrate (1m) from the summary data.
 
         Returns:
-            int: Current hashrate (1m), or False if not available.
+            int: Hashrate (1m), or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["hashrate"][1])
             return self._backends_response[2]["threads"][0]["hashrate"][1]
-        log.error(f"An error occurred fetching the cached Cuda threads hashrates (1m) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads hashrates (1m) data: {e}")
+            return False
 
     @property
     def be_cuda_threads_hashrate_15m(self) -> int | bool:
@@ -2553,13 +2677,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current hashrate (15m) from the summary data.
 
         Returns:
-            int: Current hashrate (15m), or False if not available.
+            int: Hashrate (15m), or False if not available.
         """
-        if self._summary_response and "hashrate" in self._summary_response:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["hashrate"][2])
             return self._backends_response[2]["threads"][0]["hashrate"][2]
-        log.error(f"An error occurred fetching the cached Cuda threads hashrates (15m) data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads hashrates (15m) data: {e}")
+            return False
 
     @property
     def be_cuda_threads_name(self) -> str | bool:
@@ -2567,13 +2692,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads name info from the backends data.
 
         Returns:
-            str: Current threads name info, or False if not available.
+            str: Threads name info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["name"])
             return self._backends_response[2]["threads"][0]["name"]
-        log.error(f"An error occurred fetching the cached Cuda threads name data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads name data: {e}")
+            return False
 
     @property
     def be_cuda_threads_bus_id(self) -> str | bool:
@@ -2581,13 +2707,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads bus ID info from the backends data.
 
         Returns:
-            str: Current threads bus ID info, or False if not available.
+            str: Threads bus ID info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["bus_id"])
             return self._backends_response[2]["threads"][0]["bus_id"]
-        log.error(f"An error occurred fetching the cached Cuda threads bus ID data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads bus ID data: {e}")
+            return False
 
     @property
     def be_cuda_threads_smx(self) -> int | bool:
@@ -2595,13 +2722,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads smx info from the backends data.
 
         Returns:
-            int: Current threads smx info, or False if not available.
+            int: Threads smx info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["smx"])
             return self._backends_response[2]["threads"][0]["smx"]
-        log.error(f"An error occurred fetching the cached Cuda threads smx data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads smx data: {e}")
+            return False
 
     @property
     def be_cuda_threads_arch(self) -> int | bool:
@@ -2609,13 +2737,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads arch info from the backends data.
 
         Returns:
-            int: Current threads arch info, or False if not available.
+            int: Threads arch info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["arch"])
             return self._backends_response[2]["threads"][0]["arch"]
-        log.error(f"An error occurred fetching the cached Cuda threads arch data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads arch data: {e}")
+            return False
 
     @property
     def be_cuda_threads_global_mem(self) -> int | bool:
@@ -2623,13 +2752,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads global memory info from the backends data.
 
         Returns:
-            int: Current threads global mem info, or False if not available.
+            int: Threads global mem info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["global_mem"])
             return self._backends_response[2]["threads"][0]["global_mem"]
-        log.error(f"An error occurred fetching the cached Cuda threads global memory data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads global memory data: {e}")
+            return False
 
     @property
     def be_cuda_threads_clock(self) -> int | bool:
@@ -2637,13 +2767,14 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads clock info from the backends data.
 
         Returns:
-            int: Current threads clock info, or False if not available.
+            int: Threads clock info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["clock"])
             return self._backends_response[2]["threads"][0]["clock"]
-        log.error(f"An error occurred fetching the cached Cuda threads clock info data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads clock info data: {e}")
+            return False
 
     @property
     def be_cuda_threads_memory_clock(self) -> int | bool:
@@ -2651,10 +2782,11 @@ class XMRigAPI:
         Retrieves the cached Cuda current threads memory clock info from the backends data.
 
         Returns:
-            int: Current threads memory_clock info, or False if not available.
+            int: Threads memory clock info, or False if not available.
         """
-        if self._backends_response and "threads" in self._backends_response[2]:
+        try:
             log.debug(self._backends_response[2]["threads"][0]["memory_clock"])
             return self._backends_response[2]["threads"][0]["memory_clock"]
-        log.error(f"An error occurred fetching the cached Cuda threads memory clock data.")
-        return False
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached Cuda threads memory clock data: {e}")
+            return False

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -3,6 +3,8 @@ import random, requests
 import subprocess
 from enum import Enum
 from datetime import timedelta
+from sys import platform
+
 
 class XMRigAuthorizationError(Exception):
     def __init__(self, message="Access token is required but not provided. Please provide a valid access token."):
@@ -130,6 +132,18 @@ class XMRig:
             subprocess.Popen(self._generate_execution_command())
         else:
             subprocess.Popen(f"{self._xmrig_path} -c {self._config_path}")
+
+    def stop_xmrig(self):
+        system_platform = platform.system()
+        try:
+            if system_platform == "Windows":
+                subprocess.run(["taskkill", "/f", "/im", "xmrig.exe"], check=True)
+            elif system_platform == "Linux" or system_platform == "Darwin":
+                subprocess.run(["pkill", "-f", "xmrig"], check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to stop xmrig: {e}")
+        else:
+            print("xmrig process terminated successfully.")
 
     def restart_xmrig(self):
         if self._http_api_token is not None:

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -88,8 +88,6 @@ class XMRig:
         self._cuda_enabled = cuda_enabled
         self._pools = pools
 
-        print(self._generate_execution_command())
-
         if self._http_api_port is not None:
             if self._http_api_port < 0 or self._http_api_port > 65535:
                 raise XMRigAPIPortError(port=self.http_api_port)
@@ -132,6 +130,12 @@ class XMRig:
             subprocess.Popen(self._generate_execution_command())
         else:
             subprocess.Popen(f"{self._xmrig_path} -c {self._config_path}")
+
+    def restart_xmrig(self):
+        if self._http_api_token is not None:
+            self.API.restart_miner()
+
+
 class XMRigAPI:
     """
     A class to interact with the XMRig miner API.

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -1339,8 +1339,20 @@ class XMRigAPI:
                     backend_types.append(i["type"])
             log.debug(backend_types)
             return backend_types
-        log.error(f"An error occurred fetching the cached enabled backends data.")
-        return False
+    @property
+    def be_cpu_type(self) -> str | bool:
+        """
+        Retrieves the cached CPU type status value from the backends data.
+
+        Returns:
+            str: Type, or None if not available.
+        """
+        try:
+            log.debug(self._backends_response[0]["type"])
+            return self._backends_response[0]["type"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU type status data: {e}")
+            return False
 
     @property
     def be_cpu_enabled(self) -> bool | None:
@@ -1482,8 +1494,203 @@ class XMRigAPI:
         if self._backends_response and "memory" in self._backends_response[0]:
             log.debug(self._backends_response[0]["memory"])
             return self._backends_response[0]["memory"]
-        log.error(f"An error occurred fetching the cached CPU memory data.")
-        return False
+    @property
+    def be_cpu_hashrates(self) -> int | bool:
+        """
+        Retrieves the cached CPU hashrates information from the backends data.
+
+        Returns:
+            int: Hashrates information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[0]["hashrate"])
+            return self._backends_response[0]["hashrate"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU hashrates data: {e}")
+            return False
+    
+    @property
+    def be_cpu_hashrate_10s(self) -> int | bool:
+        """
+        Retrieves the cached CPU hashrate (10s) information from the backends data.
+
+        Returns:
+            int: Hashrate (10s) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[0]["hashrate"][0])
+            return self._backends_response[0]["hashrate"][0]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU hashrate (10s) data: {e}")
+            return False
+    
+    @property
+    def be_cpu_hashrate_1m(self) -> int | bool:
+        """
+        Retrieves the cached CPU hashrate (1m) information from the backends data.
+
+        Returns:
+            int: Hashrate (1m) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[0]["hashrate"][1])
+            return self._backends_response[0]["hashrate"][1]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU hashrate (1m) data: {e}")
+            return False
+    
+    @property
+    def be_cpu_hashrate_15m(self) -> int | bool:
+        """
+        Retrieves the cached CPU hashrate (15m) information from the backends data.
+
+        Returns:
+            int: Hashrate (15m) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[0]["hashrate"][2])
+            return self._backends_response[0]["hashrate"][2]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU hashrate (15m) data: {e}")
+            return False
+    
+    @property
+    def be_cpu_threads(self) -> list | bool:
+        """
+        Retrieves the cached CPU threads information from the backends data.
+
+        Returns:
+            list: Threads information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[0]["threads"])
+            return self._backends_response[0]["threads"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU threads data: {e}")
+            return False
+
+    @property
+    def be_cpu_threads_intensity(self) -> list | bool:
+        """
+        Retrieves the cached CPU threads intensity information from the backends data.
+
+        Returns:
+            list: Threads intensity information, or False if not available.
+        """
+        intensities = []
+        try:
+            for i in self._backends_response[0]["threads"]:
+                intensities.append(i["intensity"])
+            log.debug(intensities)
+            return intensities
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU threads intensity data: {e}")
+            return False
+    
+    @property
+    def be_cpu_threads_affinity(self) -> list | bool:
+        """
+        Retrieves the cached CPU threads affinity information from the backends data.
+
+        Returns:
+            list: Threads affinity information, or False if not available.
+        """
+        affinities = []
+        try:
+            for i in self._backends_response[0]["threads"]:
+                affinities.append(i["affinity"])
+            log.debug(affinities)
+            return affinities
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU threads affinity data: {e}")
+            return False
+    
+    @property
+    def be_cpu_threads_av(self) -> list | bool:
+        """
+        Retrieves the cached CPU threads av information from the backends data.
+
+        Returns:
+            list: Threads av information, or False if not available.
+        """
+        avs = []
+        try:
+            for i in self._backends_response[0]["threads"]:
+                avs.append(i["av"])
+            log.debug(avs)
+            return avs
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU threads av data: {e}")
+            return False
+    
+    @property
+    def be_cpu_threads_hashrates_10s(self) -> list | bool:
+        """
+        Retrieves the cached CPU threads hashrates (10s) information from the backends data.
+
+        Returns:
+            list: Threads hashrates (10s) information, or False if not available.
+        """
+        hashrates_10s = []
+        try:
+            for i in self._backends_response[0]["threads"]:
+                hashrates_10s.append(i["hashrate"][0])
+            log.debug(hashrates_10s)
+            return hashrates_10s
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU threads hashrates (10s) data: {e}")
+            return False
+    
+    @property
+    def be_cpu_threads_hashrates_1m(self) -> list | bool:
+        """
+        Retrieves the cached CPU threads hashrates (1m) information from the backends data.
+
+        Returns:
+            list: Threads hashrates (1m) information, or False if not available.
+        """
+        hashrates_1m = []
+        try:
+            for i in self._backends_response[0]["threads"]:
+                hashrates_1m.append(i["hashrate"][1])
+            log.debug(hashrates_1m)
+            return hashrates_1m
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU threads hashrates (1m) data: {e}")
+            return False
+    
+    @property
+    def be_cpu_threads_hashrates_15m(self) -> list | bool:
+        """
+        Retrieves the cached CPU threads hashrates (15m) information from the backends data.
+
+        Returns:
+            list: Threads hashrates (15m) information, or False if not available.
+        """
+        hashrates_15m = []
+        try:
+            for i in self._backends_response[0]["threads"]:
+                hashrates_15m.append(i["hashrate"][0])
+            log.debug(hashrates_15m)
+            return hashrates_15m
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached CPU threads hashrates (15m) data: {e}")
+            return False
+
+    @property
+    def be_opencl_type(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL type information from the backends data.
+
+        Returns:
+            str: Type information, or None if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["type"])
+            return self._backends_response[1]["type"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL type data: {e}")
+            return None
 
     @property
     def be_opencl_enabled(self) -> bool | None:
@@ -1538,8 +1745,485 @@ class XMRigAPI:
         if self._backends_response and "platform" in self._backends_response[1]:
             log.debug(self._backends_response[1]["platform"])
             return self._backends_response[1]["platform"]
-        log.error(f"An error occurred fetching the cached OpenCL platform data.")
-        return False
+    @property
+    def be_opencl_platform_index(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL platform index information from the backends data.
+
+        Returns:
+            int: Platform index information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["platform"]["index"])
+            return self._backends_response[1]["platform"]["index"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL platform index data: {e}")
+            return False
+    
+    @property
+    def be_opencl_platform_profile(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL platform profile information from the backends data.
+
+        Returns:
+            str: Platform profile information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["platform"]["profile"])
+            return self._backends_response[1]["platform"]["profile"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL platform profile data: {e}")
+            return False
+    
+    @property
+    def be_opencl_platform_version(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL platform version information from the backends data.
+
+        Returns:
+            str: Platform version information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["platform"]["version"])
+            return self._backends_response[1]["platform"]["version"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL platform version data: {e}")
+            return False
+    
+    @property
+    def be_opencl_platform_name(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL platform name information from the backends data.
+
+        Returns:
+            str: Platform name information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["platform"]["name"])
+            return self._backends_response[1]["platform"]["name"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL platform name data: {e}")
+            return False
+    
+    @property
+    def be_opencl_platform_vendor(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL platform vendor information from the backends data.
+
+        Returns:
+            str: Platform vendor information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["platform"]["vendor"])
+            return self._backends_response[1]["platform"]["vendor"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL platform vendor data: {e}")
+            return False
+    
+    @property
+    def be_opencl_platform_extensions(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL platform extensions information from the backends data.
+
+        Returns:
+            str: Platform extensions information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["platform"]["extensions"])
+            return self._backends_response[1]["platform"]["extensions"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL platform extensions data: {e}")
+            return False
+    
+    @property
+    def be_opencl_hashrates(self) -> list | bool:
+        """
+        Retrieves the cached OpenCL hashrates information from the backends data.
+
+        Returns:
+            list: Hashrates information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["hashrate"])
+            return self._backends_response[1]["hashrate"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL hashrates data: {e}")
+            return False
+    
+    @property
+    def be_opencl_hashrate_10s(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL hashrate (10s) information from the backends data.
+
+        Returns:
+            int: Hashrate (10s) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["hashrate"][0])
+            return self._backends_response[1]["hashrate"][0]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL hashrate (10s) data: {e}")
+            return False
+    
+    @property
+    def be_opencl_hashrate_1m(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL hashrate (1m) information from the backends data.
+
+        Returns:
+            int: Hashrate (1m) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["hashrate"][1])
+            return self._backends_response[1]["hashrate"][1]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL hashrate (1m) data: {e}")
+            return False
+    
+    @property
+    def be_opencl_hashrate_15m(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL hashrate (15m) information from the backends data.
+
+        Returns:
+            int: Hashrate (15m) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["hashrate"][2])
+            return self._backends_response[1]["hashrate"][2]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL hashrate (15m) data: {e}")
+            return False
+
+    @property
+    def be_opencl_threads(self) -> dict | bool:
+        """
+        Retrieves the cached OpenCL threads information from the backends data.
+
+        Returns:
+            dict: Threads information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0])
+            return self._backends_response[1]["threads"][0]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads data: {e}")
+            return False
+
+    @property
+    def be_opencl_threads_index(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads index information from the backends data.
+
+        Returns:
+            int: Threads index information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["index"])
+            return self._backends_response[1]["threads"][0]["index"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads index data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_intensity(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads intensity information from the backends data.
+
+        Returns:
+            int: Threads intensity information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["intensity"])
+            return self._backends_response[1]["threads"][0]["intensity"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads intensity data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_worksize(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads worksize information from the backends data.
+
+        Returns:
+            int: Threads worksize information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["worksize"])
+            return self._backends_response[1]["threads"][0]["worksize"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads worksize data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_amount(self) -> list | bool:
+        """
+        Retrieves the cached OpenCL threads amount information from the backends data.
+
+        Returns:
+            list: Threads amount information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["threads"])
+            return self._backends_response[1]["threads"][0]["threads"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads amount data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_unroll(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads unroll information from the backends data.
+
+        Returns:
+            int: Threads unroll information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["unroll"])
+            return self._backends_response[1]["threads"][0]["unroll"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads unroll data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_affinity(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads affinity information from the backends data.
+
+        Returns:
+            int: Threads affinity information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["affinity"])
+            return self._backends_response[1]["threads"][0]["affinity"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads affinity data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_hashrates(self) -> list | bool:
+        """
+        Retrieves the cached OpenCL threads hashrates information from the backends data.
+
+        Returns:
+            list: Threads hashrates information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["hashrate"])
+            return self._backends_response[1]["threads"][0]["hashrate"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads hashrates data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_hashrates_10s(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads hashrates (10s) information from the backends data.
+
+        Returns:
+            int: Threads hashrates (10s) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["hashrate"][0])
+            return self._backends_response[1]["threads"][0]["hashrate"][0]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads hashrates (10s) data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_hashrates_1m(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads hashrates (1m) information from the backends data.
+
+        Returns:
+            int: Threads hashrates (1m) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["hashrate"][1])
+            return self._backends_response[1]["threads"][0]["hashrate"][1]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads hashrates (1m) data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_hashrates_15m(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads hashrates (15m) information from the backends data.
+
+        Returns:
+            int: Threads hashrates (15m) information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["hashrate"][2])
+            return self._backends_response[1]["threads"][0]["hashrate"][2]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads hashrates (15m) data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_board(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL threads board information from the backends data.
+
+        Returns:
+            str: Threads board information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["board"])
+            return self._backends_response[1]["threads"][0]["board"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads board data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_name(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL threads name information from the backends data.
+
+        Returns:
+            str: Threads name information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["name"])
+            return self._backends_response[1]["threads"][0]["name"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads name data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_bus_id(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL threads bus ID information from the backends data.
+
+        Returns:
+            str: Threads bus ID information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["bus_id"])
+            return self._backends_response[1]["threads"][0]["bus_id"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads bus ID data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_cu(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads cu information from the backends data.
+
+        Returns:
+            int: Threads cu information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["cu"])
+            return self._backends_response[1]["threads"][0]["cu"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads cu data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_global_mem(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads global memory information from the backends data.
+
+        Returns:
+            int: Threads global memory information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["global_mem"])
+            return self._backends_response[1]["threads"][0]["global_mem"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads global memory data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_health(self) -> dict | bool:
+        """
+        Retrieves the cached OpenCL threads health information from the backends data.
+
+        Returns:
+            dict: Threads health information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["health"])
+            return self._backends_response[1]["threads"][0]["health"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads health data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_health_temp(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads health temperature information from the backends data.
+
+        Returns:
+            int: Threads health temperature information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["health"]["temperature"])
+            return self._backends_response[1]["threads"][0]["health"]["temperature"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads health temperature data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_health_power(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads health power information from the backends data.
+
+        Returns:
+            int: Threads health power information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["health"]["power"])
+            return self._backends_response[1]["threads"][0]["health"]["power"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads health power data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_health_clock(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads health clock information from the backends data.
+
+        Returns:
+            int: Threads health clock information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["health"]["clock"])
+            return self._backends_response[1]["threads"][0]["health"]["clock"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads health clock data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_health_mem_clock(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads health memory clock information from the backends data.
+
+        Returns:
+            int: Threads health memory clock information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["health"]["mem_clock"])
+            return self._backends_response[1]["threads"][0]["health"]["mem_clock"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads health memory clock data: {e}")
+            return False
+    
+    @property
+    def be_opencl_threads_health_rpm(self) -> int | bool:
+        """
+        Retrieves the cached OpenCL threads health rpm information from the backends data.
+
+        Returns:
+            int: Threads health rpm information, or False if not available.
+        """
+        try:
+            log.debug(self._backends_response[1]["threads"][0]["health"]["rpm"])
+            return self._backends_response[1]["threads"][0]["health"]["rpm"]
+        except Exception as e:
+            log.error(f"An error occurred fetching the cached OpenCL threads health rpm data: {e}")
+            return False
 
     @property
     def be_cuda_type(self) -> str | bool:

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -106,23 +106,6 @@ class XMRigAPI:
             print(f"An error occurred setting the Authorization Header: {e}")
             return False
 
-    def _save_config(self, config: dict) -> bool:
-        """
-        Save updated config, to be used in conjunction with `post_config` to update the config.
-
-        Args:
-            config (dict): Updated configuration to be used.
-
-        Returns:
-            bool: True if the config is saved, or False if an error occurred
-        """
-        try:
-            self._new_config = config
-            return True
-        except Exception as e:
-            print(f"An error occurred saving the config: {e}")
-            return False
-
     def get_summary(self) -> requests.Response | bool:
         """
         Fetches the summary data from the XMRig API.
@@ -181,7 +164,7 @@ class XMRigAPI:
             print(f"An error occurred while connecting to {self._config_url}: {e}")
             return False
 
-    def post_config(self) -> bool:
+    def post_config(self, config: dict) -> bool:
         """
         Updates the config data via the XMRig API.
 
@@ -190,7 +173,7 @@ class XMRigAPI:
         """
         try:
             self._post_config_response = requests.post(
-                self._config_url, json=self._new_config, headers=self._headers)
+                self._config_url, json=config, headers=self._headers)
             if self._post_config_response.status_code == 401:
                 raise XMRigAuthorizationError()
             # Raise an HTTPError for bad responses (4xx and 5xx)

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -1,163 +1,31 @@
-import os, random, requests, subprocess
-import psutil
-from enum import Enum
+"""
+XMRig API interaction library.
+
+Provides classes and methods to interact with the XMRig miner API for tasks such 
+as fetching status, managing configurations, and controlling the mining process.
+"""
+
+import requests
 from datetime import timedelta
-import platform
+
 
 class XMRigAuthorizationError(Exception):
+    """
+    Exception raised when an authorization error occurs with the XMRig API.
+
+    Attributes:
+        message (str): Error message explaining the authorization issue.
+    """
+
     def __init__(self, message="Access token is required but not provided. Please provide a valid access token."):
+        """
+        Initialize the authorization error.
+
+        Args:
+            message (str): Error message. Defaults to a generic authorization error message.
+        """
         self.message = message
         super().__init__(self.message)
-
-class XMRigAPIPortError(Exception):
-    def __init__(self, port):
-        super().__init__(f"Unable to connect to XMRig API! {port} is not a valid port!")
-
-class XMRigPoolError(Exception):
-    def __init__(self, message):
-        super().__init__(message)
-
-class PoolCoin(Enum):
-    MONERO = "monero"
-    WOWNERO = "wownero"
-    LOKI = "loki"
-    ARQMA = "arqma"
-    MASARI = "masari"
-    ITALO = "italo"
-    GRIN = "grin"
-    HAVEN = "haven"
-    TURTLECOIN = "turtlecoin"
-    BITTUBE = "bittube"
-    FREEHAVEN = "freehaven"
-    GRAFT = "graft"
-    ULTRONIUM = "ultronium"
-    KRB = "krb"  # Karbo
-    NERVA = "nerva"
-    Saronite = "saronite"
-    Torque = "torque"
-
-class PoolAlgorithm(Enum):
-    RX_0 = "rx/0"  # RandomX default
-    RX_WOW = "rx/wow"  # RandomX WowNero
-    RX_LUA = "rx/lua"  # RandomX Lua
-    RX_ARQ = "rx/arq"  # RandomX ArQmA
-    RX_SFX = "rx/sfx"  # RandomX Safex
-    RX_XLA = "rx/xla"  # RandomX Scala
-    CN_0 = "cn/0"  # CryptoNight default (CNv0)
-    CN_1 = "cn/1"  # CryptoNight variant 1 (CNv1)
-    CN_FAST = "cn/fast"  # CryptoNight variant 2 (CNv2, aka CNFast)
-    CN_HEAVY = "cn/heavy"  # CryptoNight Heavy
-    CN_PICO = "cn/pico"  # CryptoNight Pico
-    CN_HALF = "cn/half"  # CryptoNight Half
-    CN_GPU = "cn/gpu"  # CryptoNight GPU
-    CN_R = "cn/r"  # CryptoNight R
-    CN_RWZ = "cn/rwz"  # CryptoNight ReverseWaltz
-    CN_ZLS = "cn/zls"  # CryptoNight ZLS
-    CN_DOUBLE = "cn/double"  # CryptoNight Double
-    CN_CCX = "cn/ccx"  # CryptoNight Conceal
-    CN_XAO = "cn/xao"  # CryptoNight Alloy
-    CN_TRTL = "cn/trtl"  # CryptoNight Turtle
-    CN_HAVEN = "cn/haven"  # CryptoNight Haven
-    CN_TUBE = "cn/tube"  # CryptoNight BitTube
-    CN_MSR = "cn/msr"  # CryptoNight Masari
-    CN_GR = "cn/gr"  # CryptoNight Graft
-    CN_RTO = "cn/rto"  # CryptoNight Rito
-
-class XMRigPool():
-    def __init__(self, coin:PoolCoin, algorithm:PoolAlgorithm, url:str, user:str, port:int=3333, password:str="x", tls:bool=False, keep_alive:bool=True, nice_hash:bool=False):
-        self.coin = coin
-        self.algorithm = algorithm.value
-        self.url = url
-        self.port = port
-        self.user = user
-        self.password = password
-        self.tls = tls
-        self.keep_alive = keep_alive
-        self.nice_hash = nice_hash
-
-class XMRig:
-    def __init__(self, config_path: str = None, xmrig_path: str = "xmrig", http_api_port: int = random.randint(1, 65535), http_api_token: str = None, donate_level: int = 5, api_worker_id: str = None, http_api_host: str = "0.0.0.0", opencl_enabled: bool = False, cuda_enabled: bool = False, pools: list = None):
-        self._xmrig_path = xmrig_path
-        self._config_path = config_path
-        self._http_api_port = http_api_port
-        self._http_api_token = http_api_token
-        self._donate_level = donate_level
-        self._api_worker_id = api_worker_id
-        self._http_api_host = http_api_host
-        self._opencl_enabled = opencl_enabled
-        self._cuda_enabled = cuda_enabled
-        self._pools = pools if pools else []
-        self._api_enabled = False
-
-        if self._http_api_port is not None:
-            if self._http_api_port < 0 or self._http_api_port > 65535:
-                raise XMRigAPIPortError(port=self._http_api_port)
-
-            if self._http_api_token is not None:
-                self.API = XMRigAPI("127.0.0.1", self._http_api_port, self._http_api_token)
-                self._api_enabled = True
-            else:
-                self.API = XMRigAPI("127.0.0.1", self._http_api_port)
-                self._api_enabled = True
-
-        for x in self._pools:
-            if not isinstance(x, XMRigPool):
-                raise TypeError(f"Pool {x} must be a XMRigPool instance!")
-
-    def _generate_execution_command(self):
-        cmd = [self._xmrig_path, "--donate-level", str(self._donate_level)]
-        if self._api_worker_id:
-            cmd.extend(["--api-worker-id", self._api_worker_id])
-        cmd.extend(["--http-host", self._http_api_host, "--http-port", str(self._http_api_port)])
-        if self._http_api_token:
-            cmd.extend(["--http-access-token", self._http_api_token])
-        if self._opencl_enabled:
-            cmd.append("--opencl")
-        if self._cuda_enabled:
-            cmd.append("--cuda")
-        for pool in self._pools:
-            cmd.extend(["-o", f"{pool.url}:{pool.port}", "-u", pool.user, "-p", pool.password])
-            if pool.tls:
-                cmd.append("--tls")
-            if pool.keep_alive:
-                cmd.append("-k")
-            if pool.nice_hash:
-                cmd.append("--nicehash")
-            if pool.coin:
-                cmd.extend(["--coin", pool.coin.value])
-            if pool.algorithm:
-                cmd.extend(["-a", pool.algorithm])
-        return cmd
-
-    def _is_process_running(self):
-        """Check if XMRig is already running"""
-        for proc in psutil.process_iter(['pid', 'name']):
-            if 'xmrig' in proc.info['name']:
-                return True
-        return False
-
-    def start_xmrig(self):
-        if not self._is_process_running():
-            if self._config_path is not None:
-                subprocess.Popen([self._xmrig_path, "-c", self._config_path], creationflags=subprocess.CREATE_NEW_CONSOLE)
-            else:
-                cmd = self._generate_execution_command()
-                subprocess.Popen(cmd, creationflags=subprocess.CREATE_NEW_CONSOLE)
-
-    def stop_xmrig(self):
-        if self._is_process_running():
-            system_platform = platform.system()
-            try:
-                if system_platform == "Windows":
-                    subprocess.run(["taskkill", "/f", "/im", "xmrig.exe"], check=True)
-                elif system_platform in ("Linux", "Darwin"):
-                    subprocess.run(["pkill", "-f", "xmrig"], check=True)
-            except subprocess.CalledProcessError:
-                pass
-
-    def restart_xmrig(self):
-        self.stop_xmrig()
-        self.start_xmrig()
 
 
 class XMRigAPI:
@@ -169,302 +37,1699 @@ class XMRigAPI:
         _port (int): Port of the XMRig API.
         _access_token (str): Access token for authorization.
         _base_url (str): Base URL for the XMRig API.
+        _json_rpc_url (str): URL for the json RPC.
         _summary_url (str): URL for the summary endpoint.
-        _hashrate (float): Cached hashrate value.
-        _uptime (int): Cached uptime value.
-        _accepted_jobs (int): Cached number of accepted jobs.
-        _rejected_jobs (int): Cached number of rejected jobs.
-        _paused (bool): Cached paused status of the miner.
+        _backends_url (str): URL for the backends endpoint.
+        _config_url (str): URL for the config endpoint.
+        _summary_response (dict): Response from the summary endpoint.
+        _backends_response (dict): Response from the backends endpoint.
+        _config_response (dict): Response from the config `GET` endpoint.
+        _post_config_response (dict): Response from the config `PUT` endpoint.
+        _new_config (dict): Config to update with.
+        _headers (dict): Headers for all API/RPC requests.
+        _json_rpc_payload (dict): Default payload to send with RPC request.
     """
 
-    def __init__(self, ip, port, access_token: str = None):
+    def __init__(self, ip: str, port: str, access_token: str = None, tls_enabled: bool = False):
         """
         Initializes the XMRig instance with the provided IP, port, and access token.
 
+        The `ip` can be either an IP address or domain name with its TLD (e.g. `example.com`). The schema is not 
+        required and the appropriate one will be chosen based on the `tls_enabled` value.
+
         Args:
-            ip (str): IP address of the XMRig API.
+            ip (str): IP address or domain of the XMRig API.
             port (int): Port of the XMRig API.
             access_token (str, optional): Access token for authorization. Defaults to None.
+            tls_enabled (bool, optional): TLS status of the miner/API. 
         """
         self._ip = ip
         self._port = port
         self._access_token = access_token
-        self._base_url = f"http://{ip}:{port}/2"
-        self._summary_url = f"{self._base_url}/summary"
-        self._hashrate = None
-        self._uptime = None
-        self._accepted_jobs = None
-        self._rejected_jobs = None
-        self._paused = None
+        self._base_url = f"http://{ip}:{port}"
+        if tls_enabled == True:
+            self._base_url = f"https://{ip}:{port}"
+        self._json_rpc_url = f"{self._base_url}/json_rpc"
+        self._summary_url = f"{self._base_url}/2/summary"
+        self._backends_url = f"{self._base_url}/2/backends"
+        self._config_url = f"{self._base_url}/2/config"
+        self._summary_response = None
+        self._backends_response = None
+        self._config_response = None
+        self._post_config_response = None
+        self._new_config = None
+        self._headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Host": f"{self._base_url}",
+            "Connection": "keep-alive",
+            "Authorization": f"Bearer {self._access_token}"
+        }
+        self._json_rpc_payload = {
+            "method": None,
+            "jsonrpc": "2.0",
+            "id": 1,
+        }
+        self.get_all_responses()
 
-    def _get_headers(self):
+    def _set_auth_header(self) -> bool:
         """
-        Constructs the headers for the HTTP requests, including the authorization token if provided.
+        Update the Authorization header for the HTTP requests.
 
         Returns:
-            dict: Headers for the HTTP request.
+            bool: True if the Authorization header was changed, or False if an error occurred.
         """
-        headers = {}
-        if self._access_token:
-            headers['Authorization'] = f"Bearer {self._access_token}"
-        return headers
+        try:
+            self._headers['Authorization'] = f"Bearer {self._access_token}"
+            return True
+        except Exception as e:
+            print(f"An error occurred setting the Authorization Header: {e}")
+            return False
 
-    def fetch_summary(self):
+    def _save_config(self, config: dict) -> bool:
+        """
+        Save updated config, to be used in conjunction with `post_config` to update the config.
+
+        Args:
+            config (dict): Updated configuration to be used.
+
+        Returns:
+            bool: True if the config is saved, or False if an error occurred
+        """
+        try:
+            self._new_config = config
+            return True
+        except Exception as e:
+            print(f"An error occurred saving the config: {e}")
+            return False
+
+    def get_summary(self) -> requests.Response | bool:
         """
         Fetches the summary data from the XMRig API.
 
         Returns:
-            dict: Parsed JSON response from the summary endpoint, or None if an error occurred.
+            dict: Parsed JSON response from the summary endpoint, or False if an error occurred.
         """
-        headers = self._get_headers()
         try:
-            response = requests.get(self._summary_url, headers=headers)
-            if response.status_code == 401:
+            summary_response = requests.get(
+                self._summary_url, headers=self._headers)
+            if summary_response.status_code == 401:
                 raise XMRigAuthorizationError()
-            response.raise_for_status()  # Raise an HTTPError for bad responses (4xx and 5xx)
-            return response.json()
+            # Raise an HTTPError for bad responses (4xx and 5xx)
+            summary_response.raise_for_status()
+            return summary_response.json()
         except requests.exceptions.RequestException as e:
             print(f"An error occurred while connecting to {self._summary_url}: {e}")
-            return None
+            return False
 
-    def pause_miner(self):
+    def get_backends(self) -> requests.Response | bool:
+        """
+        Fetches the backends data from the XMRig API.
+
+        Returns:
+            dict: Parsed JSON response from the backends endpoint, or False if an error occurred.
+        """
+        try:
+            backends_response = requests.get(
+                self._backends_url, headers=self._headers)
+            if backends_response.status_code == 401:
+                raise XMRigAuthorizationError()
+            # Raise an HTTPError for bad responses (4xx and 5xx)
+            backends_response.raise_for_status()
+            return backends_response.json()
+        except requests.exceptions.RequestException as e:
+            print(f"An error occurred while connecting to {self._backends_url}: {e}")
+            return False
+
+    def get_config(self) -> requests.Response | bool:
+        """
+        Fetches the config data from the XMRig API.
+
+        Returns:
+            dict: Parsed JSON response from the config endpoint (GET), or False if an error occurred.
+        """
+        try:
+            config_response = requests.get(
+                self._config_url, headers=self._headers)
+            if config_response.status_code == 401:
+                raise XMRigAuthorizationError()
+            # Raise an HTTPError for bad responses (4xx and 5xx)
+            config_response.raise_for_status()
+            self._config_response = config_response.json()
+            return self._config_response
+        except requests.exceptions.RequestException as e:
+            print(f"An error occurred while connecting to {self._config_url}: {e}")
+            return False
+
+    def post_config(self) -> bool:
+        """
+        Updates the config data via the XMRig API.
+
+        Returns:
+            bool: True if the config was changed successfully, or False if an error occurred.
+        """
+        try:
+            self._post_config_response = requests.post(
+                self._config_url, json=self._new_config, headers=self._headers)
+            if self._post_config_response.status_code == 401:
+                raise XMRigAuthorizationError()
+            # Raise an HTTPError for bad responses (4xx and 5xx)
+            self._post_config_response.raise_for_status()
+            return True
+        except requests.exceptions.RequestException as e:
+            print(f"An error occurred while connecting to {self._config_url}: {e}")
+            return False
+
+    def get_all_responses(self) -> bool:
+        """
+        Retrieves all responses from the API.
+
+        Returns:
+            bool: True if successfull, or False if an error occurred.
+        """
+        try:
+            self._summary_response = self.get_summary()
+            self._backends_response = self.get_backends()
+            if self._access_token != None:
+                self._config_response = self.get_config()
+            return True
+        except Exception as e:
+            print(f"An error occurred fetching all the API endpoints: {e}")
+            return False
+
+    def pause_miner(self) -> bool:
         """
         Pauses the miner.
 
         Returns:
-            bool: True if the miner was successfully paused, False otherwise.
+            bool: True if the miner was successfully paused, or False if an error occurred.
         """
-        headers = self._get_headers()
         try:
-            response = requests.post(self._pause_url, headers=headers)
+            url = f"{self._json_rpc_url}"
+            payload = self._json_rpc_payload
+            payload["method"] = "pause"
+            response = requests.post(url, json=payload, headers=self._headers)
             response.raise_for_status()
             return True
         except requests.exceptions.RequestException as e:
             return False
 
-    def resume_miner(self):
+    def resume_miner(self) -> bool:
         """
         Resumes the miner.
 
         Returns:
-            bool: True if the miner was successfully resumed, False otherwise.
+            bool: True if the miner was successfully resumed, or False if an error occurred.
         """
-        headers = self._get_headers()
         try:
-            response = requests.post(self._resume_url, headers=headers)
+            url = f"{self._json_rpc_url}"
+            payload = self._json_rpc_payload
+            payload["method"] = "resume"
+            response = requests.post(url, json=payload, headers=self._headers)
             response.raise_for_status()
             return True
         except requests.exceptions.RequestException as e:
             return False
 
-    def restart_miner(self):
-        """
-        Restarts the miner.
-
-        Returns:
-            bool: True if the miner was successfully restarted, False otherwise.
-        """
-        headers = self._get_headers()
-        try:
-            response = requests.post(self._restart_url, headers=headers)
-            response.raise_for_status()
-            return True
-        except requests.exceptions.RequestException as e:
-            return False
-
-    def stop_miner(self):
+    def stop_miner(self) -> bool:
         """
         Stops the miner.
 
         Returns:
-            bool: True if the miner was successfully stopped, False otherwise.
+            bool: True if the miner was successfully stopped, or False if an error occurred.
         """
-        headers = self._get_headers()
         try:
-            response = requests.post(self._stop_url, headers=headers)
+            url = f"{self._json_rpc_url}"
+            payload = self._json_rpc_payload
+            payload["method"] = "stop"
+            response = requests.post(url, json=payload, headers=self._headers)
             response.raise_for_status()
             return True
         except requests.exceptions.RequestException as e:
             return False
 
-    @property
-    def hashrate(self):
+    # TODO: The `start` json RPC method is not implemented by XMRig yet, use alternative function below until PR 3030 is 
+    # TODO: merged see https://github.com/xmrig/xmrig/issues/2826#issuecomment-1146465641
+    # TODO: https://github.com/xmrig/xmrig/issues/3220#issuecomment-1450691309 and
+    # TODO: https://github.com/xmrig/xmrig/pull/3030 for more infomation.
+    def start_miner(self) -> bool:
         """
-        Retrieves the current hashrate from the summary data.
+        Starts the miner.
 
         Returns:
-            float: Current hashrate, or None if not available.
+            bool: True if the miner was successfully started, or False if an error occurred.
         """
-        summary = self.fetch_summary()
-        if summary and "hashrate" in summary:
-            self._hashrate = summary["hashrate"]["total"][0]
-        return self._hashrate
+        try:
+            self.get_config()
+            self.post_config()
+            return True
+        except requests.exceptions.RequestException as e:
+            return False
 
     @property
-    def uptime(self):
+    def summary(self) -> dict |bool:
         """
-        Retrieves the current uptime from the summary data.
+        Retrieves the entire cached summary endpoint data.
 
         Returns:
-            int: Current uptime in seconds, or None if not available.
+            dict: Current summary response, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "uptime" in summary:
-            self._uptime = summary["uptime"]
-        return self._uptime
+        if self._summary_response:
+            return self._summary_response
+        return False
 
     @property
-    def accepted_jobs(self):
+    def backends(self) -> dict | bool:
         """
-        Retrieves the number of accepted jobs from the summary data.
+        Retrieves the entire cached backends endpoint data.
 
         Returns:
-            int: Number of accepted jobs, or None if not available.
+            dict: Current backends response, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "connection" in summary:
-            self._accepted_jobs = summary["connection"]["accepted"]
-        return self._accepted_jobs
+        if self._backends_response:
+            return self._backends_response
+        return False
 
     @property
-    def rejected_jobs(self):
+    def config(self) -> dict | bool:
         """
-        Retrieves the number of rejected jobs from the summary data.
+        Retrieves the entire cached config endpoint data.
 
         Returns:
-            int: Number of rejected jobs, or None if not available.
+            dict: Current config response, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "connection" in summary:
-            self._rejected_jobs = summary["connection"]["rejected"]
-        return self._rejected_jobs
+        if self._config_response:
+            return self._config_response
+        return False
 
     @property
-    def miner_paused(self):
+    def sum_id(self) -> str | bool:
         """
-        Retrieves the paused status of the miner from the summary data.
+        Retrieves the cached ID information from the summary data.
 
         Returns:
-            bool: True if the miner is paused, False otherwise, or None if not available.
+            str: ID information, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "paused" in summary:
-            self._paused = summary["paused"]
-        return self._paused
+        if self._summary_response and "id" in self._summary_response:
+            return self._summary_response["id"]
+        return False
 
     @property
-    def total_hashes(self):
+    def sum_worker_id(self) -> str | bool:
         """
-        Retrieves the total number of hashes from the summary data.
+        Retrieves the cached worker ID information from the summary data.
 
         Returns:
-            int: Total number of hashes, or None if not available.
+            str: Worker ID information, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "results" in summary:
-            return summary["results"]["hashes_total"]
+        if self._summary_response and "worker_id" in self._summary_response:
+            return self._summary_response["worker_id"]
+        return False
+
+    @property
+    def sum_uptime(self) -> int | bool:
+        """
+        Retrieves the cached current uptime from the summary data.
+
+        Returns:
+            int: Current uptime in seconds, or False if not available.
+        """
+        if self._summary_response and "uptime" in self._summary_response:
+            return self._summary_response["uptime"]
+        return False
+
+    @property
+    def sum_uptime_readable(self) -> str | bool:
+        """
+        Retrieves the cached uptime in a human-readable format from the summary data.
+
+        Returns:
+            str: Uptime in the format "days, hours:minutes:seconds", or False if not available.
+        """
+        if self._summary_response and "uptime" in self._summary_response:
+            return str(timedelta(seconds=self._summary_response["uptime"]))
+        return False
+
+    @property
+    def sum_restricted(self) -> bool | None:
+        """
+        Retrieves the cached current restricted status from the summary data.
+
+        Returns:
+            bool: Current restricted status, or None if not available.
+        """
+        if self._summary_response and "restricted" in self._summary_response:
+            return self._summary_response["restricted"]
         return None
 
     @property
-    def current_difficulty(self):
+    def sum_resources(self) -> dict | bool:
         """
-        Retrieves the current difficulty from the summary data.
+        Retrieves the cached resources information from the summary data.
 
         Returns:
-            int: Current difficulty, or None if not available.
+            dict: Resources information, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "results" in summary:
-            return summary["results"]["diff_current"]
+        if self._summary_response and "resources" in self._summary_response:
+            return self._summary_response["resources"]
+        return False
+
+    @property
+    def sum_memory_usage(self) -> dict | bool:
+        """
+        Retrieves the cached memory usage from the summary data.
+
+        Returns:
+            dict: Memory usage information, or False if not available.
+        """
+        if self._summary_response and "memory" in self._summary_response["resources"]:
+            return self._summary_response["resources"]["memory"]
+        return False
+
+    @property
+    def sum_free_memory(self) -> int | bool:
+        """
+        Retrieves the cached free memory from the summary data.
+
+        Returns:
+            int: Free memory information, or False if not available.
+        """
+        if self._summary_response and "free" in self._summary_response["resources"]["memory"]:
+            return self._summary_response["resources"]["memory"]["free"]
+        return False
+
+    @property
+    def sum_total_memory(self) -> int | bool:
+        """
+        Retrieves the cached total memory from the summary data.
+
+        Returns:
+            int: Total memory information, or False if not available.
+        """
+        if self._summary_response and "total" in self._summary_response["resources"]["memory"]:
+            return self._summary_response["resources"]["memory"]["total"]
+        return False
+
+    @property
+    def sum_resident_set_memory(self) -> int | bool:
+        """
+        Retrieves the cached resident set memory from the summary data.
+
+        Returns:
+            int: Resident set memory information, or False if not available.
+        """
+        if self._summary_response and "resident_set" in self._summary_response["resources"]["memory"]:
+            return self._summary_response["resources"]["memory"]["resident_set_memory"]
+        return False
+
+    @property
+    def sum_load_average(self) -> list | bool:
+        """
+        Retrieves the cached load average from the summary data.
+
+        Returns:
+            list: Load average information, or False if not available.
+        """
+        if self._summary_response and "load_average" in self._summary_response["resources"]:
+            return self._summary_response["resources"]["load_average"]
+        return False
+
+    @property
+    def sum_hardware_concurrency(self) -> int | bool:
+        """
+        Retrieves the cached hardware concurrency from the summary data.
+
+        Returns:
+            int: Hardware concurrency information, or False if not available.
+        """
+        if self._summary_response and "hardware_concurrency" in self._summary_response["resources"]:
+            return self._summary_response["resources"]["hardware_concurrency"]
+        return False
+
+    @property
+    def sum_features(self) -> list | bool:
+        """
+        Retrieves the cached supported features information from the summary data.
+
+        Returns:
+            list: Supported features information, or False if not available.
+        """
+        if self._summary_response and "features" in self._summary_response["resources"]:
+            return self._summary_response["resources"]["features"]
+        return False
+
+    @property
+    def sum_results(self) -> dict | bool:
+        """
+        Retrieves the cached results information from the summary data.
+
+        Returns:
+            dict: Results information, or False if not available.
+        """
+        if self._summary_response and "results" in self._summary_response:
+            return self._summary_response["results"]
+        return False
+
+    @property
+    def sum_current_difficulty(self) -> int | bool:
+        """
+        Retrieves the cached current difficulty from the summary data.
+
+        Returns:
+            int: Current difficulty, or False if not available.
+        """
+        if self._summary_response and "results" in self._summary_response:
+            return self._summary_response["results"]["diff_current"]
+        return False
+
+    @property
+    def sum_good_shares(self) -> int | bool:
+        """
+        Retrieves the cached good shares from the summary data.
+
+        Returns:
+            int: Good shares, or False if not available.
+        """
+        if self._summary_response and "results" in self._summary_response:
+            return self._summary_response["results"]["shares_good"]
+        return False
+
+    @property
+    def sum_total_shares(self) -> int | bool:
+        """
+        Retrieves the cached total shares from the summary data.
+
+        Returns:
+            int: Total shares, or False if not available.
+        """
+        if self._summary_response and "results" in self._summary_response:
+            return self._summary_response["results"]["shares_total"]
+        return False
+
+    @property
+    def sum_avg_time(self) -> int | bool:
+        """
+        Retrieves the cached average time information from the summary data.
+
+        Returns:
+            int: Average time information, or False if not available.
+        """
+        if self._summary_response and "results" in self._summary_response:
+            return self._summary_response["results"]["avg_time"]
+        return False
+
+    @property
+    def sum_avg_time_ms(self) -> int | bool:
+        """
+        Retrieves the cached average time in `ms` information from the summary data.
+
+        Returns:
+            int: Average time in `ms` information, or False if not available.
+        """
+        if self._summary_response and "results" in self._summary_response:
+            return self._summary_response["results"]["avg_time_ms"]
+        return False
+
+    @property
+    def sum_total_hashes(self) -> int | bool:
+        """
+        Retrieves the cached total number of hashes from the summary data.
+
+        Returns:
+            int: Total number of hashes, or False if not available.
+        """
+        if self._summary_response and "results" in self._summary_response:
+            return self._summary_response["results"]["hashes_total"]
+        return False
+
+    @property
+    def sum_best_results(self) -> list | bool:
+        """
+        Retrieves the cached best results from the summary data.
+
+        Returns:
+            list: Best results, or False if not available.
+        """
+        if self._summary_response and "results" in self._summary_response:
+            return self._summary_response["results"]["best"]
+        return False
+
+    @property
+    def sum_algorithm(self) -> str | bool:
+        """
+        Retrieves the cached current mining algorithm from the summary data.
+
+        Returns:
+            str: Current mining algorithm, or False if not available.
+        """
+        if self._summary_response and "algo" in self._summary_response:
+            return self._summary_response["algo"]
+        return False
+
+    @property
+    def sum_connection(self) -> dict | bool:
+        """
+        Retrieves the cached connection information from the summary data.
+
+        Returns:
+            dict: Connection information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]
+        return False
+
+    @property
+    def sum_pool_info(self) -> str | bool:
+        """
+        Retrieves the cached pool information from the summary data.
+
+        Returns:
+            str: Pool information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["pool"]
+        return False
+
+    @property
+    def sum_pool_ip_address(self) -> str | bool:
+        """
+        Retrieves the cached IP address from the summary data.
+
+        Returns:
+            str: IP address, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["ip"]
+        return False
+
+    @property
+    def sum_pool_uptime(self) -> int | bool:
+        """
+        Retrieves the cached pool uptime information from the summary data.
+
+        Returns:
+            int: Pool uptime information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["uptime"]
+        return False
+
+    @property
+    def sum_pool_uptime_ms(self) -> int | bool:
+        """
+        Retrieves the cached pool uptime in ms from the summary data.
+
+        Returns:
+            int: Pool uptime in ms, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["uptime_ms"]
+        return False
+
+    @property
+    def sum_pool_ping(self) -> int | bool:
+        """
+        Retrieves the cached pool ping information from the summary data.
+
+        Returns:
+            int: Pool ping information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["ping"]
+        return False
+
+    @property
+    def sum_pool_failures(self) -> int | bool:
+        """
+        Retrieves the cached pool failures information from the summary data.
+
+        Returns:
+            int: Pool failures information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["failures"]
+        return False
+
+    @property
+    def sum_pool_tls(self) -> bool | None:
+        """
+        Retrieves the cached pool tls status from the summary data.
+
+        Returns:
+            bool: Pool tls status, or None if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["tls"]
         return None
 
     @property
-    def pool_info(self):
+    def sum_pool_tls_fingerprint(self) -> str | bool:
         """
-        Retrieves the pool information from the summary data.
+        Retrieves the cached pool tls fingerprint information from the summary data.
 
         Returns:
-            dict: Pool information, or None if not available.
+            str: Pool tls fingerprint information, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "connection" in summary:
-            return summary["connection"]["pool"]
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["tls-fingerprint"]
+        return False
+
+    @property
+    def sum_pool_algo(self) -> str | bool:
+        """
+        Retrieves the cached pool algorithm information from the summary data.
+
+        Returns:
+            str: Pool algorithm information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["algo"]
+        return False
+
+    @property
+    def sum_pool_diff(self) -> int | bool:
+        """
+        Retrieves the cached pool difficulty information from the summary data.
+
+        Returns:
+            int: Pool difficulty information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["diff"]
+        return False
+
+    @property
+    def sum_pool_accepted_jobs(self) -> int | bool:
+        """
+        Retrieves the cached number of accepted jobs from the summary data.
+
+        Returns:
+            int: Number of accepted jobs, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["accepted"]
+        return False
+
+    @property
+    def sum_pool_rejected_jobs(self) -> int | bool:
+        """
+        Retrieves the cached number of rejected jobs from the summary data.
+
+        Returns:
+            int: Number of rejected jobs, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["rejected"]
+        return False
+
+    @property
+    def sum_pool_average_time(self) -> int | bool:
+        """
+        Retrieves the cached pool average time information from the summary data.
+
+        Returns:
+            int: Pool average time information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["avg_time"]
+        return False
+
+    @property
+    def sum_pool_average_time_ms(self) -> int | bool:
+        """
+        Retrieves the cached pool average in ms from the summary data.
+
+        Returns:
+            int: Pool average in ms, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["avg_time_ms"]
+        return False
+
+    @property
+    def sum_pool_total_hashes(self) -> int | bool:
+        """
+        Retrieves the cached pool total hashes information from the summary data.
+
+        Returns:
+            int: Pool total hashes information, or False if not available.
+        """
+        if self._summary_response and "connection" in self._summary_response:
+            return self._summary_response["connection"]["hashes_total"]
+        return False
+
+    @property
+    def sum_version(self) -> str | bool:
+        """
+        Retrieves the cached version information from the summary data.
+
+        Returns:
+            str: Version information, or False if not available.
+        """
+        if self._summary_response and "version" in self._summary_response:
+            return self._summary_response["version"]
+        return False
+
+    @property
+    def sum_kind(self) -> str | bool:
+        """
+        Retrieves the cached kind information from the summary data.
+
+        Returns:
+            str: Kind information, or False if not available.
+        """
+        if self._summary_response and "kind" in self._summary_response:
+            return self._summary_response["kind"]
+        return False
+
+    @property
+    def sum_ua(self) -> str | bool:
+        """
+        Retrieves the cached user agent information from the summary data.
+
+        Returns:
+            str: User agent information, or False if not available.
+        """
+        if self._summary_response and "ua" in self._summary_response:
+            return self._summary_response["ua"]
+        return False
+
+    @property
+    def sum_cpu_info(self) -> dict | bool:
+        """
+        Retrieves the cached CPU information from the summary data.
+
+        Returns:
+            dict: CPU information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]
+        return False
+
+    @property
+    def sum_cpu_brand(self) -> str | bool:
+        """
+        Retrieves the cached CPU brand information from the summary data.
+
+        Returns:
+            str: CPU brand information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["brand"]
+        return False
+
+    @property
+    def sum_cpu_family(self) -> int | bool:
+        """
+        Retrieves the cached CPU family information from the summary data.
+
+        Returns:
+            int: CPU family information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["family"]
+        return False
+
+    @property
+    def sum_cpu_model(self) -> int | bool:
+        """
+        Retrieves the cached CPU model information from the summary data.
+
+        Returns:
+            int: CPU model information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["model"]
+        return False
+
+    @property
+    def sum_cpu_stepping(self) -> int | bool:
+        """
+        Retrieves the cached CPU stepping information from the summary data.
+
+        Returns:
+            int: CPU stepping information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["stepping"]
+        return False
+
+    @property
+    def sum_cpu_proc_info(self) -> int | bool:
+        """
+        Retrieves the cached CPU frequency information from the summary data.
+
+        Returns:
+            int: CPU frequency information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["proc_info"]
+        return False
+
+    @property
+    def sum_cpu_aes(self) -> int | bool:
+        """
+        Retrieves the cached CPU aes information from the summary data.
+
+        Returns:
+            int: CPU aes information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["aes"]
+        return False
+
+    @property
+    def sum_cpu_avx2(self) -> int | bool:
+        """
+        Retrieves the cached CPU avx2 information from the summary data.
+
+        Returns:
+            int: CPU avx2 information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["avx2"]
+        return False
+
+    @property
+    def sum_cpu_x64(self) -> int | bool:
+        """
+        Retrieves the cached CPU x64 information from the summary data.
+
+        Returns:
+            int: CPU x64 information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["x64"]
+        return False
+
+    @property
+    def sum_cpu_64_bit(self) -> int | bool:
+        """
+        Retrieves the cached CPU 64-bit information from the summary data.
+
+        Returns:
+            int: CPU 64-bit information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["64_bit"]
+        return False
+
+    @property
+    def sum_cpu_l2(self) -> int | bool:
+        """
+        Retrieves the cached CPU l2 cache information from the summary data.
+
+        Returns:
+            int: CPU l2 cache information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["l2"]
+        return False
+
+    @property
+    def sum_cpu_l3(self) -> int | bool:
+        """
+        Retrieves the cached CPU l3 cache information from the summary data.
+
+        Returns:
+            int: CPU l3 cache information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["l3"]
+        return False
+
+    @property
+    def sum_cpu_cores(self) -> int | bool:
+        """
+        Retrieves the cached CPU cores information from the summary data.
+
+        Returns:
+            int: CPU cores information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["cores"]
+        return False
+
+    @property
+    def sum_cpu_threads(self) -> int | bool:
+        """
+        Retrieves the cached CPU threads information from the summary data.
+
+        Returns:
+            int: CPU threads information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["threads"]
+        return False
+
+    @property
+    def sum_cpu_packages(self) -> int | bool:
+        """
+        Retrieves the cached CPU packages information from the summary data.
+
+        Returns:
+            int: CPU packages information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["packages"]
+        return False
+
+    @property
+    def sum_cpu_nodes(self) -> int | bool:
+        """
+        Retrieves the cached CPU nodes information from the summary data.
+
+        Returns:
+            int: CPU nodes information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["nodes"]
+        return False
+
+    @property
+    def sum_cpu_backend(self) -> str | bool:
+        """
+        Retrieves the cached CPU backend information from the summary data.
+
+        Returns:
+            str: CPU backend information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["backend"]
+        return False
+
+    @property
+    def sum_cpu_msr(self) -> str | bool:
+        """
+        Retrieves the cached CPU msr information from the summary data.
+
+        Returns:
+            str: CPU msr information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["msr"]
+        return False
+
+    @property
+    def sum_cpu_assembly(self) -> str | bool:
+        """
+        Retrieves the cached CPU assembly information from the summary data.
+
+        Returns:
+            str: CPU assembly information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["assembly"]
+        return False
+
+    @property
+    def sum_cpu_arch(self) -> str | bool:
+        """
+        Retrieves the cached CPU architecture information from the summary data.
+
+        Returns:
+            str: CPU architecture information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["arch"]
+        return False
+
+    @property
+    def sum_cpu_flags(self) -> list | bool:
+        """
+        Retrieves the cached CPU flags information from the summary data.
+
+        Returns:
+            list: CPU flags information, or False if not available.
+        """
+        if self._summary_response and "cpu" in self._summary_response:
+            return self._summary_response["cpu"]["flags"]
+        return False
+
+    @property
+    def sum_donate_level(self) -> int | bool:
+        """
+        Retrieves the cached donation level information from the summary data.
+
+        Returns:
+            int: Donation level information, or False if not available.
+        """
+        if self._summary_response and "donate_level" in self._summary_response:
+            return self._summary_response["donate_level"]
+        return False
+
+    @property
+    def sum_paused(self) -> int | bool:
+        """
+        Retrieves the cached paused status of the miner from the summary data.
+
+        Returns:
+            int: True if the miner is paused, False otherwise, or False if not available.
+        """
+        if self._summary_response and "paused" in self._summary_response:
+            return self._summary_response["paused"]
+        return False
+
+    @property
+    def sum_algorithms(self) -> list | bool:
+        """
+        Retrieves the cached algorithms information from the summary data.
+
+        Returns:
+            list: Algorithms information, or False if not available.
+        """
+        if self._summary_response and "algorithms" in self._summary_response:
+            return self._summary_response["algorithms"]
+        return False
+
+    @property
+    def sum_hashrates(self) -> dict | bool:
+        """
+        Retrieves the cached current hashrates from the summary data.
+
+        Returns:
+            dict: Current hashrates, or False if not available.
+        """
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._summary_response["hashrate"]
+        return False
+
+    @property
+    def sum_hashrate_10s(self) -> int | bool:
+        """
+        Retrieves the cached current hashrate (10s) from the summary data.
+
+        Returns:
+            int: Current hashrate (10s), or False if not available.
+        """
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._summary_response["hashrate"]["total"][0]
+        return False
+
+    @property
+    def sum_hashrate_1m(self) -> int | bool:
+        """
+        Retrieves the cached current hashrate (1m) from the summary data.
+
+        Returns:
+            int: Current hashrate (1m), or False if not available.
+        """
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._summary_response["hashrate"]["total"][1]
+        return False
+
+    @property
+    def sum_hashrate_15m(self) -> int | bool:
+        """
+        Retrieves the cached current hashrate (15m) from the summary data.
+
+        Returns:
+            int: Current hashrate (15m), or False if not available.
+        """
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._summary_response["hashrate"]["total"][2]
+        return False
+
+    @property
+    def sum_hashrate_highest(self) -> int | bool:
+        """
+        Retrieves the cached current hashrate (highest) from the summary data.
+
+        Returns:
+            int: Current hashrate (highest), or False if not available.
+        """
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._summary_response["hashrate"]["highest"]
+        return False
+
+    @property
+    def sum_hugepages(self) -> list | bool:
+        """
+        Retrieves the cached current hugepages from the summary data.
+
+        Returns:
+            list: Current hugepages, or False if not available.
+        """
+        if self._summary_response and "hugepages" in self._summary_response:
+            return self._summary_response["hugepages"]
+        return False
+
+    # * Data Provided by the backends endpoint
+    @property
+    def enabled_backends(self) -> list | bool:
+        """
+        Retrieves the cached currently enabled backends from the backends data.
+
+        Returns:
+            list: List of enabled backends, or False if not available.
+        """
+        types = []
+        if self._backends_response:
+            for i in self._backends_response:
+                if "type" in i and i["enabled"] == True:
+                    types.append(i["type"])
+            return types
+        return False
+
+    @property
+    def be_cpu_enabled(self) -> bool | None:
+        """
+        Retrieves the cached CPU enabled status value from the backends data.
+
+        Returns:
+            bool: Bool representing enabled status, or None if not available.
+        """
+        if self._backends_response and "enabled" in self._backends_response[0]:
+            return self._backends_response[0]["enabled"]
         return None
 
     @property
-    def cpu_info(self):
+    def be_cpu_algo(self) -> str | bool:
         """
-        Retrieves the CPU information from the summary data.
+        Retrieves the cached CPU algorithm information from the backends data.
 
         Returns:
-            dict: CPU information, or None if not available.
+            str: Bool representing algorithm information, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "cpu" in summary:
-            return summary["cpu"]
+        if self._backends_response and "algo" in self._backends_response[0]:
+            return self._backends_response[0]["algo"]
+        return False
+
+    @property
+    def be_cpu_profile(self) -> str | bool:
+        """
+        Retrieves the cached CPU profile information from the backends data.
+
+        Returns:
+            str: Bool representing profile information, or False if not available.
+        """
+        if self._backends_response and "profile" in self._backends_response[0]:
+            return self._backends_response[0]["profile"]
+        return False
+
+    @property
+    def be_cpu_hw_aes(self) -> bool | None:
+        """
+        Retrieves the cached CPU hw-aes support value from the backends data.
+
+        Returns:
+            bool: Bool representing hw-aes support status, or None if not available.
+        """
+        if self._backends_response and "hw-aes" in self._backends_response[0]:
+            return self._backends_response[0]["hw-aes"]
         return None
 
     @property
-    def version(self):
+    def be_cpu_priority(self) -> int | bool:
         """
-        Retrieves the version information from the summary data.
+        Retrieves the cached CPU  priority from the backends data. 
+
+        Value from 1 (lowest priority) to 5 (highest possible priority). Default 
+        value `-1` means XMRig doesn't change threads priority at all,
 
         Returns:
-            str: Version information, or None if not available.
+            int: Int representing mining thread priority, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "version" in summary:
-            return summary["version"]
+        if self._backends_response and "priority" in self._backends_response[0]:
+            return self._backends_response[0]["priority"]
+        return False
+
+    @property
+    def be_cpu_msr(self) -> bool | None:
+        """
+        Retrieves the cached CPU msr information from the backends data.
+
+        Returns:
+            bool: Bool representing msr information, or None if not available.
+        """
+        if self._backends_response and "msr" in self._backends_response[0]:
+            return self._backends_response[0]["msr"]
         return None
 
     @property
-    def uptime_readable(self):
+    def be_cpu_asm(self) -> str | bool:
         """
-        Retrieves the uptime in a human-readable format from the summary data.
+        Retrieves the cached CPU asm information from the backends data.
 
         Returns:
-            str: Uptime in the format "days, hours:minutes:seconds", or None if not available.
+            str: Bool representing asm information, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "uptime" in summary:
-            return str(timedelta(seconds=summary["uptime"]))
+        if self._backends_response and "asm" in self._backends_response[0]:
+            return self._backends_response[0]["asm"]
+        return False
+
+    @property
+    def be_cpu_argon2_impl(self) -> str | bool:
+        """
+        Retrieves the cached CPU argon2 implementation information from the backends data.
+
+        Returns:
+            str: Bool representing argon2 implementation information, or False if not available.
+        """
+        if self._backends_response and "argon2-impl" in self._backends_response[0]:
+            return self._backends_response[0]["argon2-impl"]
+        return False
+
+    @property
+    def be_cpu_hugepages(self) -> list | bool:
+        """
+        Retrieves the cached CPU hugepages information from the backends data.
+
+        Returns:
+            list: Bool representing hugepages information, or False if not available.
+        """
+        if self._backends_response and "hugepages" in self._backends_response[0]:
+            return self._backends_response[0]["hugepages"]
+        return False
+
+    @property
+    def be_cpu_memory(self) -> int | bool:
+        """
+        Retrieves the cached CPU memory information from the backends data.
+
+        Returns:
+            int: Bool representing memory information, or False if not available.
+        """
+        if self._backends_response and "memory" in self._backends_response[0]:
+            return self._backends_response[0]["memory"]
+        return False
+
+    @property
+    def be_opencl_enabled(self) -> bool | None:
+        """
+        Retrieves the cached OpenCL enabled information from the backends data.
+
+        Returns:
+            bool: Bool representing enabled information, or None if not available.
+        """
+        if self._backends_response and "enabled" in self._backends_response[1]:
+            return self._backends_response[1]["enabled"]
         return None
 
     @property
-    def memory_usage(self):
+    def be_opencl_algo(self) -> str | bool:
         """
-        Retrieves the memory usage from the summary data.
+        Retrieves the cached OpenCL algorithm information from the backends data.
 
         Returns:
-            dict: Memory usage information, or None if not available.
+            str: Bool representing algorithm information, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "resources" in summary and "memory" in summary["resources"]:
-            return summary["resources"]["memory"]
+        if self._backends_response and "algo" in self._backends_response[1]:
+            return self._backends_response[1]["algo"]
+        return False
+
+    @property
+    def be_opencl_profile(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL profile information from the backends data.
+
+        Returns:
+            str: Bool representing profile information, or False if not available.
+        """
+        if self._backends_response and "profile" in self._backends_response[1]:
+            return self._backends_response[1]["profile"]
+        return False
+
+    @property
+    def be_opencl_platform(self) -> str | bool:
+        """
+        Retrieves the cached OpenCL platform information from the backends data.
+
+        Returns:
+            str: Bool representing platform information, or False if not available.
+        """
+        if self._backends_response and "platform" in self._backends_response[1]:
+            return self._backends_response[1]["platform"]
+        return False
+
+    @property
+    def be_cuda_type(self) -> str | bool:
+        """
+        Retrieves the cached Cuda current type info from the backends data.
+
+        Returns:
+            str: Current type info, or False if not available.
+        """
+        if self._backends_response and "type" in self._backends_response[2]:
+            return self._backends_response[2]["type"]
+        return False
+
+    @property
+    def be_cuda_enabled(self) -> bool | None:
+        """
+        Retrieves the cached Cuda current enabled info from the backends data.
+
+        Returns:
+            bool: Current enabled info, or None if not available.
+        """
+        if self._backends_response and "enabled" in self._backends_response[2]:
+            return self._backends_response[2]["enabled"]
         return None
 
     @property
-    def load_average(self):
+    def be_cuda_algo(self) -> str | bool:
         """
-        Retrieves the load average from the summary data.
+        Retrieves the cached Cuda algorithm information from the backends data.
 
         Returns:
-            list: Load average information, or None if not available.
+            str: Bool representing algorithm information, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "resources" in summary and "load_average" in summary["resources"]:
-            return summary["resources"]["load_average"]
+        if self._backends_response and "algo" in self._backends_response[2]:
+            return self._backends_response[2]["algo"]
+        return False
+
+    @property
+    def be_cuda_profile(self) -> str | bool:
+        """
+        Retrieves the cached Cuda profile information from the backends data.
+
+        Returns:
+            str: Bool representing profile information, or False if not available.
+        """
+        if self._backends_response and "profile" in self._backends_response[2]:
+            return self._backends_response[2]["profile"]
+        return False
+
+    @property
+    def be_cuda_versions(self) -> dict | bool:
+        """
+        Retrieves the cached Cuda versions information from the backends data.
+
+        Returns:
+            dict: Bool representing versions information, or False if not available.
+        """
+        if self._backends_response and "versions" in self._backends_response[2]:
+            return self._backends_response[2]["versions"]
+        return False
+
+    @property
+    def be_cuda_runtime(self) -> str | bool:
+        """
+        Retrieves the cached Cuda runtime information from the backends data.
+
+        Returns:
+           str: Bool representing cuda runtime information, or False if not available.
+        """
+        if self._backends_response and "cuda-runtime" in self._backends_response[2]:
+            return self._backends_response[2]["versions"]["cuda-runtime"]
+        return False
+
+    @property
+    def be_cuda_driver(self) -> str | bool:
+        """
+        Retrieves the cached Cuda driver information from the backends data.
+
+        Returns:
+            str: Bool representing cuda driver information, or False if not available.
+        """
+        if self._backends_response and "cuda-driver" in self._backends_response[2]:
+            return self._backends_response[2]["versions"]["cuda-driver"]
+        return False
+
+    @property
+    def be_cuda_plugin(self) -> str | bool:
+        """
+        Retrieves the cached Cuda plugin information from the backends data.
+
+        Returns:
+            str: Bool representing cuda plugin information, or False if not available.
+        """
+        if self._backends_response and "plugin" in self._backends_response[2]:
+            return self._backends_response[2]["versions"]["plugin"]
+        return False
+
+    @property
+    def be_cuda_hashrate(self) -> list | bool:
+        """
+        Retrieves the cached Cuda current hashrate info from the backends data.
+
+        Returns:
+            list: Current hashrate info, or False if not available.
+        """
+        if self._backends_response and "hashrate" in self._backends_response[2]:
+            return self._backends_response[2]["hashrate"]
+        return False
+
+    @property
+    def be_cuda_hashrate_10s(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current hashrate (10s) info from the backends data.
+
+        Returns:
+           int: Current hashrate (10s) info, or False if not available.
+        """
+        if self._backends_response and "hashrate" in self._backends_response[2]:
+            return self._backends_response[2]["hashrate"][0]
+        return False
+
+    @property
+    def be_cuda_hashrate_1m(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current hashrate (1m) info from the backends data.
+
+        Returns:
+            int: Current hashrate (1m) info, or False if not available.
+        """
+        if self._backends_response and "hashrate" in self._backends_response[2]:
+            return self._backends_response[2]["hashrate"][1]
+        return False
+
+    @property
+    def be_cuda_hashrate_15m(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current hashrate (15m) info from the backends data.
+
+        Returns:
+            int: Current hashrate (15m) info, or False if not available.
+        """
+        if self._backends_response and "hashrate" in self._backends_response[2]:
+            return self._backends_response[2]["hashrate"][2]
+        return False
+
+    @property
+    def be_cuda_threads(self) -> dict | bool:
+        """
+        Retrieves the cached Cuda current threads info from the backends data.
+
+        Returns:
+            dict: Current threads info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]
+        return False
+
+    @property
+    def be_cuda_threads_index(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads index info from the backends data.
+
+        Returns:
+            int: Current threads index info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["index"]
+        return False
+
+    @property
+    def be_cuda_threads_amount(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads amount info from the backends data.
+
+        Returns:
+            int: Current threads amount info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["threads"]
+        return False
+
+    @property
+    def be_cuda_threads_blocks(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads blocks info from the backends data.
+
+        Returns:
+            int: Current threads blocks info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["blocks"]
+        return False
+
+    @property
+    def be_cuda_threads_bfactor(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads bfactor info from the backends data.
+
+        Returns:
+            int: Current threads bfactor info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["bfactor"]
+        return False
+
+    @property
+    def be_cuda_threads_bsleep(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads bsleep info from the backends data.
+
+        Returns:
+            int: Current threads bsleep info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["bsleep"]
+        return False
+
+    @property
+    def be_cuda_threads_affinity(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads affinity info from the backends data.
+
+        Returns:
+            int: Current threads affinity info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["affinity"]
+        return False
+
+    @property
+    def be_cuda_threads_dataset_host(self) -> bool | None:
+        """
+        Retrieves the cached Cuda current threads dataset host info from the backends data.
+
+        Returns:
+            bool: Current threads dataset host info, or None if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["dataset_host"]
         return None
 
     @property
-    def algorithm(self):
+    def be_cuda_threads_hashrates(self) -> list | bool:
         """
-        Retrieves the current mining algorithm from the summary data.
+        Retrieves the cached Cuda current hashrates (10s/1m/15m) from the summary data.
 
         Returns:
-            str: Current mining algorithm, or None if not available.
+            list: Current hashrates, or False if not available.
         """
-        summary = self.fetch_summary()
-        if summary and "algorithm" in summary:
-            return summary["algorithm"]
-        return None
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._backends_response[2]["threads"][0]["hashrate"]
+        return False
+
+    @property
+    def be_cuda_threads_hashrate_10s(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current hashrate (10s) from the summary data.
+
+        Returns:
+            int: Current hashrate (10s), or False if not available.
+        """
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._backends_response[2]["threads"][0]["hashrate"][0]
+        return False
+
+    @property
+    def be_cuda_threads_hashrate_1m(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current hashrate (1m) from the summary data.
+
+        Returns:
+            int: Current hashrate (1m), or False if not available.
+        """
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._backends_response[2]["threads"][0]["hashrate"][1]
+        return False
+
+    @property
+    def be_cuda_threads_hashrate_15m(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current hashrate (15m) from the summary data.
+
+        Returns:
+            int: Current hashrate (15m), or False if not available.
+        """
+        if self._summary_response and "hashrate" in self._summary_response:
+            return self._backends_response[2]["threads"][0]["hashrate"][2]
+        return False
+
+    @property
+    def be_cuda_threads_name(self) -> str | bool:
+        """
+        Retrieves the cached Cuda current threads name info from the backends data.
+
+        Returns:
+            str: Current threads name info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["name"]
+        return False
+
+    @property
+    def be_cuda_threads_bus_id(self) -> str | bool:
+        """
+        Retrieves the cached Cuda current threads bus ID info from the backends data.
+
+        Returns:
+            str: Current threads bus ID info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["bus_id"]
+        return False
+
+    @property
+    def be_cuda_threads_smx(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads smx info from the backends data.
+
+        Returns:
+            int: Current threads smx info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["smx"]
+        return False
+
+    @property
+    def be_cuda_threads_arch(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads arch info from the backends data.
+
+        Returns:
+            int: Current threads arch info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["arch"]
+        return False
+
+    @property
+    def be_cuda_threads_global_mem(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads global mem info from the backends data.
+
+        Returns:
+            int: Current threads global mem info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["global_mem"]
+        return False
+
+    @property
+    def be_cuda_threads_clock(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads clock info from the backends data.
+
+        Returns:
+            int: Current threads clock info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["clock"]
+        return False
+
+    @property
+    def be_cuda_threads_memory_clock(self) -> int | bool:
+        """
+        Retrieves the cached Cuda current threads memory clock info from the backends data.
+
+        Returns:
+            int: Current threads memory_clock info, or False if not available.
+        """
+        if self._backends_response and "threads" in self._backends_response[2]:
+            return self._backends_response[2]["threads"][0]["memory_clock"]
+        return False

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -92,7 +92,7 @@ class XMRigAPI:
             "id": 1,
         }
         self.update_all_responses()
-        log.info("XMRigAPI initialized.")
+        log.info(f"XMRigAPI initialized for {self._base_url}")
 
     def _set_auth_header(self) -> bool:
         """

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -1,10 +1,8 @@
-import os
-import random, requests
-import subprocess
+import os, random, requests, subprocess
+import psutil
 from enum import Enum
 from datetime import timedelta
 from sys import platform
-
 
 class XMRigAuthorizationError(Exception):
     def __init__(self, message="Access token is required but not provided. Please provide a valid access token."):

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -2,7 +2,7 @@ import os, random, requests, subprocess
 import psutil
 from enum import Enum
 from datetime import timedelta
-from sys import platform
+import platform
 
 class XMRigAuthorizationError(Exception):
     def __init__(self, message="Access token is required but not provided. Please provide a valid access token."):
@@ -139,12 +139,10 @@ class XMRig:
     def start_xmrig(self):
         if not self._is_process_running():
             if self._config_path is not None:
-                subprocess.Popen([self._xmrig_path, "-c", self._config_path])
+                subprocess.Popen([self._xmrig_path, "-c", self._config_path], creationflags=subprocess.CREATE_NEW_CONSOLE)
             else:
                 cmd = self._generate_execution_command()
-                subprocess.Popen(cmd)
-        else:
-            print("XMRig is already running.")
+                subprocess.Popen(cmd, creationflags=subprocess.CREATE_NEW_CONSOLE)
 
     def stop_xmrig(self):
         if self._is_process_running():
@@ -154,12 +152,12 @@ class XMRig:
                     subprocess.run(["taskkill", "/f", "/im", "xmrig.exe"], check=True)
                 elif system_platform in ("Linux", "Darwin"):
                     subprocess.run(["pkill", "-f", "xmrig"], check=True)
-            except subprocess.CalledProcessError as e:
-                print(f"Failed to stop xmrig: {e}")
-            else:
-                print("xmrig process terminated successfully.")
-        else:
-            print("XMRig is not running.")
+            except subprocess.CalledProcessError:
+                pass
+
+    def restart_xmrig(self):
+        self.stop_xmrig()
+        self.start_xmrig()
 
 
 class XMRigAPI:

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -103,7 +103,7 @@ class XMRigAPI:
         """
         try:
             self._headers['Authorization'] = f"Bearer {self._access_token}"
-            log.info(f"Authorization header successfully changed.")
+            log.debug(f"Authorization header successfully changed.")
             return True
         except Exception as e:
             log.error(f"An error occurred setting the Authorization Header: {e}")
@@ -124,7 +124,7 @@ class XMRigAPI:
             # Raise an HTTPError for bad responses (4xx and 5xx)
             summary_response.raise_for_status()
             self._summary_response = summary_response.json()
-            log.info(f"Summary endpoint successfully fetched.")
+            log.debug(f"Summary endpoint successfully fetched.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred while connecting to {self._summary_url}: {e}")
@@ -145,7 +145,7 @@ class XMRigAPI:
             # Raise an HTTPError for bad responses (4xx and 5xx)
             backends_response.raise_for_status()
             self._backends_response = backends_response.json()
-            log.info(f"Backends endpoint successfully fetched.")
+            log.debug(f"Backends endpoint successfully fetched.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred while connecting to {self._backends_url}: {e}")
@@ -166,7 +166,7 @@ class XMRigAPI:
             # Raise an HTTPError for bad responses (4xx and 5xx)
             config_response.raise_for_status()
             self._config_response = config_response.json()
-            log.info(f"Config endpoint successfully fetched.")
+            log.debug(f"Config endpoint successfully fetched.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred while connecting to {self._config_url}: {e}")
@@ -186,7 +186,7 @@ class XMRigAPI:
                 raise XMRigAuthorizationError()
             # Raise an HTTPError for bad responses (4xx and 5xx)
             self._post_config_response.raise_for_status()
-            log.info(f"Config endpoint successfully updated.")
+            log.debug(f"Config endpoint successfully updated.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred while connecting to {self._config_url}: {e}")
@@ -204,7 +204,7 @@ class XMRigAPI:
             self.update_backends()
             if self._access_token != None:
                 self.update_config()
-            log.info(f"All endpoints successfully fetched.")
+            log.debug(f"All endpoints successfully fetched.")
             return True
         except Exception as e:
             log.error(f"An error occurred fetching all the API endpoints: {e}")
@@ -223,7 +223,7 @@ class XMRigAPI:
             payload["method"] = "pause"
             response = requests.post(url, json=payload, headers=self._headers)
             response.raise_for_status()
-            log.info(f"Miner successfully paused.")
+            log.debug(f"Miner successfully paused.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred pausing the miner: {e}")
@@ -242,7 +242,7 @@ class XMRigAPI:
             payload["method"] = "resume"
             response = requests.post(url, json=payload, headers=self._headers)
             response.raise_for_status()
-            log.info(f"Miner successfully resumed.")
+            log.debug(f"Miner successfully resumed.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred restarting the miner: {e}")
@@ -261,7 +261,7 @@ class XMRigAPI:
             payload["method"] = "stop"
             response = requests.post(url, json=payload, headers=self._headers)
             response.raise_for_status()
-            log.info(f"Miner successfully stopped.")
+            log.debug(f"Miner successfully stopped.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred stopping the miner: {e}")
@@ -281,7 +281,7 @@ class XMRigAPI:
         try:
             self.update_config()
             self.post_config()
-            log.info(f"Miner successfully started.")
+            log.debug(f"Miner successfully started.")
             return True
         except requests.exceptions.RequestException as e:
             log.error(f"An error occurred starting the miner: {e}")

--- a/xmrig/xmrig.py
+++ b/xmrig/xmrig.py
@@ -34,7 +34,7 @@ class XMRigAPI:
 
     Attributes:
         _ip (str): IP address of the XMRig API.
-        _port (int): Port of the XMRig API.
+        _port (str): Port of the XMRig API.
         _access_token (str): Access token for authorization.
         _base_url (str): Base URL for the XMRig API.
         _json_rpc_url (str): URL for the json RPC.


### PR DESCRIPTION
Hi mate,

This PR is quite a large change but should fix most if not all issues with the current implementation. I have removed the old miner control functionality and replaced it with methods to control the miner by JSON RPC which allows control of multiple miners via the API.

An overview of the changes is below:

- Completes the HTTP API functionality to now include being able to `GET` and `POST` the config file.
- Replaces the old miner control functionality with the JSON RPC implementation so the miner can now be controlled via the API. 
- 120 properties defined representing the full and individual responses of the `summary` and `backends` endpoints.
- Updated docstrings and README.

Thanks
hreikin